### PR TITLE
fix: improve error handling in frente services and badge color contrast

### DIFF
--- a/src/components/atoms/simpleCardColor/index.tsx
+++ b/src/components/atoms/simpleCardColor/index.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from "react";
-import { getColorFromName } from "../../../utils/getColorFromName";
+import { getColorFromName, getTextColorFromName } from "../../../utils/getColorFromName";
 import { VariantProps, tv } from "tailwind-variants";
 
 const simpleCardColor = tv({
@@ -28,11 +28,12 @@ export type SimpleCardColorProps = VariantProps<typeof simpleCardColor> & Compon
 
 function SimpleCardColor({ selected, name, disable, ...props }: SimpleCardColorProps) {
     const selectedColor = getColorFromName(name);
+    const selectedText = getTextColorFromName(name);
 
     return (
-        <div className={`${simpleCardColor({ disable })} ${selected ? `shadow-md shadow-gray-400` : 'shadow-gray-300 shadow'}`} 
+        <div className={`${simpleCardColor({ disable })} ${selected ? `shadow-md shadow-gray-400` : 'shadow-gray-300 shadow'}`}
             style={{ transform: `${ selected ? 'translateY(-2px) translateX(-2px)' : 'none' }`}} {...props}>
-                <div className={`${!disable ? selectedColor : ''} text-white w-14 h-14 flex justify-center items-center font-black text-xl tracking-widest rounded-l-lg`}>{obterSigla(name)}</div>
+                <div className={`${!disable ? selectedColor : ''} ${!disable ? selectedText : 'text-white'} w-14 h-14 flex justify-center items-center font-black text-xl tracking-widest rounded-l-lg`}>{obterSigla(name)}</div>
                 <div className={`${disable ? 'text-white' : 'text-black'} first-line:border-l h-14 px-4 font-semibold flex items-center justify-center text-xl`}>{name}</div>
         </div>
     )

--- a/src/pages/account/components/CollaboratorFrentesDisplay.tsx
+++ b/src/pages/account/components/CollaboratorFrentesDisplay.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Afinidade } from "@/types/partnerPrepCourse/afinidades";
-import { getColorFromName } from "@/utils/getColorFromName";
+import { getColorFromName, getTextColorFromName } from "@/utils/getColorFromName";
 import { useMemo } from "react";
 
 interface CollaboratorFrentesDisplayProps {
@@ -46,11 +46,12 @@ export function CollaboratorFrentesDisplay({
           <div className="flex flex-wrap gap-2">
             {allFrentes.map((frenteNome) => {
               const frenteColor = getColorFromName(frenteNome);
+              const frenteText = getTextColorFromName(frenteNome);
               return (
                 <Badge
                   key={frenteNome}
                   variant="secondary"
-                  className={`inline-flex items-center px-3 py-1 text-xs ${frenteColor} text-white`}
+                  className={`inline-flex items-center px-3 py-1 text-xs ${frenteColor} ${frenteText}`}
                 >
                   {frenteNome}
                 </Badge>
@@ -69,11 +70,12 @@ export function CollaboratorFrentesDisplay({
           <div className="flex flex-wrap gap-2">
             {allMaterias.map((materiaNome) => {
               const materiaColor = getColorFromName(materiaNome);
+              const materiaText = getTextColorFromName(materiaNome);
               return (
                 <Badge
                   key={materiaNome}
                   variant="secondary"
-                  className={`inline-flex items-center px-3 py-1 text-xs ${materiaColor} text-white`}
+                  className={`inline-flex items-center px-3 py-1 text-xs ${materiaColor} ${materiaText}`}
                 >
                   {materiaNome}
                 </Badge>

--- a/src/pages/dashContent/modals/panelFrente.tsx
+++ b/src/pages/dashContent/modals/panelFrente.tsx
@@ -13,7 +13,8 @@ import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { useState } from "react";
 import { CgArrowsExchangeAltV } from "react-icons/cg";
 import { IoEyeSharp } from "react-icons/io5";
-import { MdModeEdit } from "react-icons/md";
+import { MdDeleteForever, MdModeEdit } from "react-icons/md";
+import ModalConfirmCancel from "@/components/organisms/modalConfirmCancel";
 import ManagerFrente from "./managerFrente";
 import OrderEditSubject from "./orderEditSubject";
 import SettingsSubject from "./settingsSubject";
@@ -26,6 +27,7 @@ interface Props {
   updateSizeFrente: (id: string, size: number) => void;
   onCreate: (body: CreateFrenteDtoInput) => Promise<void>;
   onUpdate: (body: UpdateFrenteDto) => Promise<void>;
+  onDelete?: (frenteId: string) => Promise<void>;
 }
 export function PanelFrente({
   frentes,
@@ -34,13 +36,15 @@ export function PanelFrente({
   updateSizeFrente,
   onCreate,
   onUpdate,
+  onDelete,
 }: Props) {
   const [frenteSelected, setFrenteSelected] = useState<FrenteDto | null>(null);
 
   const modals = useModals([
-    'settings',
-    'frenteEditor',
-    'orderEdit',
+    "settings",
+    "frenteEditor",
+    "orderEdit",
+    "confirmDelete",
   ]);
 
   const {
@@ -75,7 +79,7 @@ export function PanelFrente({
       headerName: "Ações",
       align: "center",
       headerAlign: "center",
-      width: 200,
+      width: 250,
       renderCell: (params) => (
         <div className="flex gap-2 justify-center">
           <Tooltip title="Visualizar temas">
@@ -88,7 +92,7 @@ export function PanelFrente({
               <IoEyeSharp className="fill-gray-500 hover:fill-black" />
             </IconButton>
           </Tooltip>
-          <Tooltip title="Editar tema">
+          <Tooltip title="Editar frente">
             <IconButton
               onClick={() => {
                 setFrenteSelected(params.row);
@@ -98,7 +102,7 @@ export function PanelFrente({
               <MdModeEdit className="fill-gray-500 hover:fill-black" />
             </IconButton>
           </Tooltip>
-          <Tooltip title="Editar order conteúdos">
+          <Tooltip title="Editar ordem conteúdos">
             <IconButton
               onClick={() => {
                 setFrenteSelected(params.row);
@@ -108,6 +112,18 @@ export function PanelFrente({
               <CgArrowsExchangeAltV className="fill-gray-500 hover:fill-black" />
             </IconButton>
           </Tooltip>
+          {onDelete && (
+            <Tooltip title="Excluir frente">
+              <IconButton
+                onClick={() => {
+                  setFrenteSelected(params.row);
+                  modals.confirmDelete.open();
+                }}
+              >
+                <MdDeleteForever className="fill-redError opacity-50 hover:opacity-100" />
+              </IconButton>
+            </Tooltip>
+          )}
         </div>
       ),
     },
@@ -153,6 +169,36 @@ export function PanelFrente({
     );
   };
 
+  const handleConfirmDelete = () => {
+    if (!frenteSelected || !onDelete) return;
+    const id = frenteSelected._id || frenteSelected.id;
+    onDelete(id)
+      .then(() => {
+        modals.confirmDelete.close();
+        setFrenteSelected(null);
+      })
+      .catch(() => {
+        // Erro já tratado pelo executeAsync no parent (toast)
+      });
+  };
+
+  const ModalConfirmDelete = () =>
+    !modals.confirmDelete.isOpen || !frenteSelected ? null : (
+      <ModalConfirmCancel
+        isOpen={modals.confirmDelete.isOpen}
+        handleClose={() => {
+          modals.confirmDelete.close();
+          setFrenteSelected(null);
+        }}
+        handleConfirm={handleConfirmDelete}
+        className="bg-white p-8 rounded-md"
+      >
+        <p className="text-gray-600">
+          Tem certeza que deseja excluir a frente &quot;{frenteSelected.nome}&quot;?
+        </p>
+      </ModalConfirmCancel>
+    );
+
   return (
     <div className="flex flex-col h-[500px] overflow-y-scroll scrollbar-hide select-none">
       <div className="flex justify-between items-center mb-2">
@@ -173,6 +219,7 @@ export function PanelFrente({
       <SettingsModal />
       <ModalFrente />
       <ModalOrderEdit />
+      <ModalConfirmDelete />
     </div>
   );
 }

--- a/src/pages/dashContent/modals/settingsFrente.tsx
+++ b/src/pages/dashContent/modals/settingsFrente.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/dtos/content/frenteDto";
 import { useToastAsync } from "@/hooks/useToastAsync";
 import { createFrente } from "@/services/content/createFrente";
+import { deleteFrente } from "@/services/content/deleteFrente";
 import { getMaterias, MateriaDto } from "@/services/content/getMaterias";
 import { updateFrente } from "@/services/content/updateFrente";
 import { getSubjects } from "@/services/content/getSubjects";
@@ -47,6 +48,7 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
   }, [token]);
 
   const handleCreate = async (body: CreateFrenteDtoInput) => {
+    const materiaId = body.materia ?? materiaSelected;
     await executeAsync({
       action: () => createFrente(body, token),
       loadingMessage: "Criando Frente ... ",
@@ -56,13 +58,20 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
         const newFrente: FrenteDto = {
           id: res.id ?? res._id,
           nome: res.nome,
-          materia: materiaSelected,
+          materia: materiaId,
           lenght: 0,
           createdAt: new Date(),
           subjects: [],
         };
-        const newFrentes: FrenteDto[] = [...frentes, newFrente];
-        setFrentes(newFrentes);
+        setFrentes((prev) => [...prev, newFrente]);
+        // Atualizar lista de matérias com o novo ObjectId da frente (evita refetch)
+        setMateriasList((prev) =>
+          prev.map((m) =>
+            m._id === materiaId
+              ? { ...m, frentes: [...(m.frentes ?? []), newFrente] }
+              : m
+          )
+        );
       },
     });
   };
@@ -95,6 +104,30 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
     });
     setFrentes(newFrentes);
   }
+
+  /** Remove a frente da lista local e da lista de matérias (usado ao excluir frente). */
+  function removeFrenteFromMateriasList(frenteId: string) {
+    const norm = (id: string) => (f: FrenteDto) => (f._id || f.id) === id;
+    setFrentes((prev) => prev.filter((f) => !norm(frenteId)(f)));
+    setMateriasList((prev) =>
+      prev.map((m) => ({
+        ...m,
+        frentes: (m.frentes ?? []).filter((f) => !norm(frenteId)(f)),
+      }))
+    );
+  }
+
+  const handleDeleteFrente = async (frenteId: string) => {
+    await executeAsync({
+      action: () => deleteFrente(frenteId, token),
+      loadingMessage: "Excluindo frente...",
+      successMessage: "Frente excluída com sucesso",
+      errorMessage: (error: Error) => error.message,
+      onSuccess: () => {
+        removeFrenteFromMateriasList(frenteId);
+      },
+    });
+  };
 
   useEffect(() => {
     if (!materiaSelected) return;
@@ -154,6 +187,7 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
                 }
                 onCreate={handleCreate}
                 onUpdate={handleUpdate}
+                onDelete={handleDeleteFrente}
               />
             </div>
           </>

--- a/src/pages/managerCollaborator/modals/showInfo.tsx
+++ b/src/pages/managerCollaborator/modals/showInfo.tsx
@@ -5,7 +5,7 @@ import { InputFactory } from "@/components/organisms/inputFactory";
 import ModalTemplate from "@/components/templates/modalTemplate";
 import { Badge } from "@/components/ui/badge";
 import { Afinidade } from "@/types/partnerPrepCourse/afinidades";
-import { getColorFromName } from "@/utils/getColorFromName";
+import { getColorFromName, getTextColorFromName } from "@/utils/getColorFromName";
 import { formatDate } from "@/utils/date";
 import { phoneMask } from "@/utils/phoneMask";
 import { useEffect, useMemo, useState } from "react";
@@ -103,7 +103,7 @@ export function ShowInfo({
                       <Badge
                         key={nome}
                         variant="secondary"
-                        className={`inline-flex items-center px-3 py-1 text-xs ${getColorFromName(nome)} text-white`}
+                        className={`inline-flex items-center px-3 py-1 text-xs ${getColorFromName(nome)} ${getTextColorFromName(nome)}`}
                       >
                         {nome}
                       </Badge>
@@ -116,7 +116,7 @@ export function ShowInfo({
                       <Badge
                         key={nome}
                         variant="secondary"
-                        className={`inline-flex items-center px-3 py-1 text-xs ${getColorFromName(nome)} text-white`}
+                        className={`inline-flex items-center px-3 py-1 text-xs ${getColorFromName(nome)} ${getTextColorFromName(nome)}`}
                       >
                         {nome}
                       </Badge>

--- a/src/services/content/createFrente.ts
+++ b/src/services/content/createFrente.ts
@@ -11,7 +11,10 @@ export async function createFrente(data: CreateFrenteDtoInput, token: string): P
     const res = await response.json()
     if(response.status !== 201){
         if(response.status >= 400) {
-            throw res
+            const msg = Array.isArray(res?.message)
+                ? res.message.join(', ')
+                : res?.message ?? "Erro ao criar frente";
+            throw new Error(msg);
         }
     }
     return res

--- a/src/services/content/deleteFrente.ts
+++ b/src/services/content/deleteFrente.ts
@@ -1,0 +1,16 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { frentes } from "../urls";
+
+export async function deleteFrente(id: string, token: string): Promise<void> {
+  const response = await fetchWrapper(`${frentes}/${id}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (response.status !== 200 && response.status !== 204) {
+    const res = await response.json();
+    throw new Error(res?.message ?? "Erro ao excluir frente");
+  }
+}

--- a/src/services/content/updateFrente.ts
+++ b/src/services/content/updateFrente.ts
@@ -12,7 +12,10 @@ export async function updateFrente(data: UpdateFrenteDto, token: string): Promis
     if(response.status !== 200){
         if(response.status >= 400) {
             const res = await response.json()
-            throw new Error(res)
+            const msg = Array.isArray(res?.message)
+                ? res.message.join(', ')
+                : res?.message ?? "Erro ao editar frente";
+            throw new Error(msg)
         }
     }
 }

--- a/src/utils/getColorFromName.ts
+++ b/src/utils/getColorFromName.ts
@@ -1,40 +1,21 @@
-/** Tons escuros (600/700) para garantir contraste com texto branco nos badges. */
-const colors = [
-  'bg-red-600',
-  'bg-orange-600',
-  'bg-amber-600',
-  'bg-emerald-600',
-  'bg-teal-600',
-  'bg-cyan-600',
-  'bg-sky-600',
-  'bg-indigo-600',
-  'bg-violet-600',
-  'bg-purple-600',
-  'bg-fuchsia-600',
-  'bg-pink-600',
-  'bg-rose-600',
-  'bg-lime-600',
-  'bg-blue-600',
-  'bg-slate-600',
-];
-
-const shadows = [
-  'shadow-red-600/50',
-  'shadow-orange-600/50',
-  'shadow-amber-600/50',
-  'shadow-emerald-600/50',
-  'shadow-teal-600/50',
-  'shadow-cyan-600/50',
-  'shadow-sky-600/50',
-  'shadow-indigo-600/50',
-  'shadow-violet-600/50',
-  'shadow-purple-600/50',
-  'shadow-fuchsia-600/50',
-  'shadow-pink-600/50',
-  'shadow-rose-600/50',
-  'shadow-lime-600/50',
-  'shadow-blue-600/50',
-  'shadow-slate-600/50',
+/** Paleta fechada de cores com contraste garantido para badges/labels. */
+const palette: { bg: string; text: string; shadow: string }[] = [
+  { bg: 'bg-red-700',     text: 'text-white', shadow: 'shadow-red-700/50' },
+  { bg: 'bg-orange-700',  text: 'text-white', shadow: 'shadow-orange-700/50' },
+  { bg: 'bg-amber-800',   text: 'text-white', shadow: 'shadow-amber-800/50' },
+  { bg: 'bg-emerald-700', text: 'text-white', shadow: 'shadow-emerald-700/50' },
+  { bg: 'bg-teal-700',    text: 'text-white', shadow: 'shadow-teal-700/50' },
+  { bg: 'bg-cyan-800',    text: 'text-white', shadow: 'shadow-cyan-800/50' },
+  { bg: 'bg-sky-700',     text: 'text-white', shadow: 'shadow-sky-700/50' },
+  { bg: 'bg-indigo-700',  text: 'text-white', shadow: 'shadow-indigo-700/50' },
+  { bg: 'bg-violet-700',  text: 'text-white', shadow: 'shadow-violet-700/50' },
+  { bg: 'bg-purple-700',  text: 'text-white', shadow: 'shadow-purple-700/50' },
+  { bg: 'bg-fuchsia-700', text: 'text-white', shadow: 'shadow-fuchsia-700/50' },
+  { bg: 'bg-pink-700',    text: 'text-white', shadow: 'shadow-pink-700/50' },
+  { bg: 'bg-rose-700',    text: 'text-white', shadow: 'shadow-rose-700/50' },
+  { bg: 'bg-lime-800',    text: 'text-white', shadow: 'shadow-lime-800/50' },
+  { bg: 'bg-blue-700',    text: 'text-white', shadow: 'shadow-blue-700/50' },
+  { bg: 'bg-slate-700',   text: 'text-white', shadow: 'shadow-slate-700/50' },
 ];
 
 const getIndex = (name: string) => {
@@ -43,15 +24,20 @@ const getIndex = (name: string) => {
         return acc + code;
     }, 0);
 
-    return (hashCode) % colors.length;
+    return (hashCode) % palette.length;
 }
 
 export const getColorFromName = (name: string) => {
-    const index = getIndex(name)
-    return `${colors[index]}`;
+    const index = getIndex(name);
+    return palette[index].bg;
+};
+
+export const getTextColorFromName = (name: string) => {
+    const index = getIndex(name);
+    return palette[index].text;
 };
 
 export const getShadowColorFromName = (name: string) => {
-    const index = getIndex(name)
-    return `${shadows[index]}`;
+    const index = getIndex(name);
+    return palette[index].shadow;
 };


### PR DESCRIPTION
- createFrente/updateFrente now throw proper Error with message from API
- Replace light -600 color palette with darker -700/-800 for badge readability
- Use getTextColorFromName for dynamic text color on all frente badges