### PR TITLE
feat(dash_menu): gestão de matérias no conteúdo

### DIFF
--- a/src/components/organisms/sidebarDash/index.tsx
+++ b/src/components/organisms/sidebarDash/index.tsx
@@ -8,11 +8,38 @@ import {
   SidebarHeader,
   SidebarMenu,
 } from "@/components/ui/sidebar";
-import { dashCardMenuItems } from "@/pages/dash/data";
-import { useState } from "react";
+import {
+  adminMenuItems,
+  buildAcademicMenuItems,
+  fallbackAcademicMenuItems,
+  studentMenuItem,
+} from "@/pages/dash/data";
+import {
+  AreaWithMaterias,
+  getMateriasGroupedByArea,
+} from "@/services/content/getMateriasGroupedByArea";
+import { useEffect, useMemo, useState } from "react";
+import { DashCardMenu } from "../../molecules/dashCard";
 
 export function SidebarDash() {
   const [opened, setOpened] = useState<number>(0);
+  const [areas, setAreas] = useState<AreaWithMaterias[] | null>(null);
+
+  useEffect(() => {
+    getMateriasGroupedByArea()
+      .then(setAreas)
+      .catch(() => setAreas(null));
+  }, []);
+
+  const academicItems = useMemo<DashCardMenu[]>(() => {
+    if (!areas) return fallbackAcademicMenuItems;
+    return buildAcademicMenuItems(areas);
+  }, [areas]);
+
+  const dashCardMenuItems = useMemo(
+    () => [...adminMenuItems, ...academicItems, studentMenuItem],
+    [academicItems],
+  );
 
   const selectCard = (cardId: number) => {
     setOpened(opened === cardId ? 0 : cardId);

--- a/src/config/materiaPresets.ts
+++ b/src/config/materiaPresets.ts
@@ -1,0 +1,81 @@
+import { ReactComponent as Artes } from "@/assets/icons/home-subjects-arte.svg";
+import { ReactComponent as Atualidades } from "@/assets/icons/home-subjects-atualidades.svg";
+import { ReactComponent as Biologia } from "@/assets/icons/home-subjects-biologia.svg";
+import { ReactComponent as Espanhol } from "@/assets/icons/home-subjects-espanhol.svg";
+import { ReactComponent as Filosofia } from "@/assets/icons/home-subjects-filosofia.svg";
+import { ReactComponent as Fisica } from "@/assets/icons/home-subjects-fisica.svg";
+import { ReactComponent as Geografia } from "@/assets/icons/home-subjects-geografia.svg";
+import { ReactComponent as Gramatica } from "@/assets/icons/home-subjects-gramatica.svg";
+import { ReactComponent as Historia } from "@/assets/icons/home-subjects-historia.svg";
+import { ReactComponent as Ingles } from "@/assets/icons/home-subjects-ingles.svg";
+import { ReactComponent as Leitura } from "@/assets/icons/home-subjects-leitura-prod-textos.svg";
+import { ReactComponent as Literatura } from "@/assets/icons/home-subjects-literatura.svg";
+import { ReactComponent as Matematica } from "@/assets/icons/home-subjects-matematica.svg";
+import { ReactComponent as Quimica } from "@/assets/icons/home-subjects-quimica.svg";
+import { ReactComponent as Sociologia } from "@/assets/icons/home-subjects-sociologia.svg";
+
+import { ReactComponent as Astronaut } from "@/assets/icons/materias/Astronaut.svg";
+import { ReactComponent as Biology } from "@/assets/icons/materias/Biology.svg";
+import { ReactComponent as English } from "@/assets/icons/materias/English.svg";
+import { ReactComponent as Geo } from "@/assets/icons/materias/Geo.svg";
+import { ReactComponent as Grammar } from "@/assets/icons/materias/Grammar.svg";
+import { ReactComponent as History } from "@/assets/icons/materias/History.svg";
+import { ReactComponent as LPT } from "@/assets/icons/materias/LPT.svg";
+import { ReactComponent as Languages } from "@/assets/icons/materias/Languages.svg";
+import { ReactComponent as LiteratureImg } from "@/assets/icons/materias/Literature.svg";
+import { ReactComponent as Math } from "@/assets/icons/materias/Math.svg";
+import { ReactComponent as Science } from "@/assets/icons/materias/Science.svg";
+import { ReactComponent as TakingEarth } from "@/assets/icons/materias/TakingEarth.svg";
+import { ReactComponent as Thoughts } from "@/assets/icons/materias/Thoughts.svg";
+
+import { FaBook } from "react-icons/fa";
+
+type SvgComponent = React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+
+/** Presets de ícone do menu lateral (home-subjects-*) */
+export const iconPresets: Record<string, SvgComponent> = {
+  biologia: Biologia,
+  fisica: Fisica,
+  quimica: Quimica,
+  matematica: Matematica,
+  historia: Historia,
+  geografia: Geografia,
+  filosofia: Filosofia,
+  sociologia: Sociologia,
+  atualidades: Atualidades,
+  gramatica: Gramatica,
+  ingles: Ingles,
+  artes: Artes,
+  espanhol: Espanhol,
+  literatura: Literatura,
+  leitura: Leitura,
+};
+
+/** Presets de imagem da página de matéria (materias/*) */
+export const imagePresets: Record<string, SvgComponent> = {
+  Astronaut,
+  Biology,
+  Geo,
+  Grammar,
+  History,
+  LPT,
+  Literature: LiteratureImg,
+  Math,
+  Science,
+  TakingEarth,
+  Thoughts,
+  English,
+  Languages,
+};
+
+export function getIconPreset(key?: string): SvgComponent {
+  if (key && iconPresets[key]) return iconPresets[key];
+  return FaBook as unknown as SvgComponent;
+}
+
+export function getImagePreset(
+  key?: string,
+): SvgComponent | undefined {
+  if (key && imagePresets[key]) return imagePresets[key];
+  return undefined;
+}

--- a/src/pages/dash/data.ts
+++ b/src/pages/dash/data.ts
@@ -47,11 +47,14 @@ import { BiSolidSchool } from "react-icons/bi";
 import { FaPeopleGroup } from "react-icons/fa6";
 import { PiStudentFill, PiUsersFourBold } from "react-icons/pi";
 
-import { FaClipboardList } from "react-icons/fa";
+import { FaBook, FaClipboardList } from "react-icons/fa";
 import { FaWpforms } from "react-icons/fa6";
+import { getIconPreset } from "../../config/materiaPresets";
 import { DashCardMenu } from "../../components/molecules/dashCard";
+import { SubDashCardInfo } from "../../components/molecules/subDashCard";
 import { HeaderData } from "../../components/organisms/header";
 import { Roles } from "../../enums/roles/roles";
+import { AreaWithMaterias } from "../../services/content/getMateriasGroupedByArea";
 import { header } from "../home/data";
 
 export const headerDash: HeaderData = {
@@ -76,7 +79,8 @@ export const headerDash: HeaderData = {
   ],
 };
 
-export const dashCardMenuItems: DashCardMenu[] = [
+// Cards administrativos (estáticos)
+export const adminMenuItems: DashCardMenu[] = [
   {
     id: 6,
     bg: "bg-red",
@@ -193,7 +197,97 @@ export const dashCardMenuItems: DashCardMenu[] = [
       },
     ],
   },
+];
 
+export const studentMenuItem: DashCardMenu = {
+  id: 7,
+  bg: "bg-red",
+  title: "Cursinho",
+  image: IoSchool,
+  alt: "Cursinho",
+  subMenuList: [
+    {
+      icon: FaClipboardList,
+      alt: "processos seletivos",
+      text: "Inscrições",
+      link: `/dashboard/${REGISTRATION_MONITOR}`,
+      permissions: [Roles.visualizarMinhasInscricoes],
+    },
+  ],
+};
+
+// Mapeamento de área do ENEM → configuração visual
+const areaConfig: Record<
+  string,
+  {
+    id: number;
+    bg: string;
+    image: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+    title: string;
+  }
+> = {
+  Linguagens: { id: 1, bg: "bg-marine", image: LinguagensImg, title: "Linguagens" },
+  "Ciências da Natureza": { id: 2, bg: "bg-pink", image: NaturezaImg, title: "Natureza" },
+  "Ciências Humanas": { id: 3, bg: "bg-lightGreen", image: HumanasImg, title: "Humanas" },
+  Matemática: { id: 4, bg: "bg-orange", image: MatematicaImg, title: "Matemática" },
+};
+
+// Mapeamento de nome da matéria → ícone e slug para rota
+const materiaConfig: Record<
+  string,
+  {
+    icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+    slug: string;
+  }
+> = {
+  "Língua Portuguesa": { icon: Gramatica, slug: "LinguaPortuguesa" },
+  "Língua Estrangeira": { icon: Ingles, slug: "LinguaEstrangeira" },
+  Artes: { icon: Artes, slug: "Artes" },
+  Biologia: { icon: Biologia, slug: "Biologia" },
+  Física: { icon: Fisica, slug: "Fisica" },
+  Química: { icon: Quimica, slug: "Quimica" },
+  Matemática: { icon: Matematica, slug: "Matematica" },
+  História: { icon: Historia, slug: "Historia" },
+  Geografia: { icon: Geografia, slug: "Geografia" },
+  Filosofia: { icon: Filosofia, slug: "Filosofia" },
+  Sociologia: { icon: Sociologia, slug: "Sociologia" },
+  Atualidades: { icon: Atualidades, slug: "Atualidades" },
+};
+
+export function buildAcademicMenuItems(
+  areas: AreaWithMaterias[],
+): DashCardMenu[] {
+  return areas
+    .map((area) => {
+      const config = areaConfig[area.enemArea];
+      if (!config) return null;
+
+      const subMenuList: SubDashCardInfo[] = area.materias.map((materia) => {
+        const icon = materia.icon
+          ? getIconPreset(materia.icon)
+          : (materiaConfig[materia.nome]?.icon ?? FaBook);
+        return {
+          icon,
+          alt: materia.nome.toLowerCase(),
+          text: materia.nome,
+          link: `${ESTUDO}/${materia._id}`,
+        };
+      });
+
+      return {
+        id: config.id,
+        bg: config.bg,
+        title: config.title,
+        image: config.image,
+        alt: config.title,
+        subMenuList,
+      };
+    })
+    .filter((item): item is DashCardMenu => item !== null);
+}
+
+// Fallback hardcoded para quando a API não estiver disponível
+export const fallbackAcademicMenuItems: DashCardMenu[] = [
   {
     id: 1,
     bg: "bg-marine",
@@ -201,24 +295,9 @@ export const dashCardMenuItems: DashCardMenu[] = [
     image: LinguagensImg,
     alt: "Linguagens",
     subMenuList: [
-      {
-        icon: Gramatica,
-        alt: "língua portuguesa",
-        text: "Língua Portuguesa",
-        link: `${ESTUDO}/LinguaPortuguesa`,
-      },
-      {
-        icon: Ingles,
-        alt: "língua estrangeira",
-        text: "Língua Estrangeira",
-        link: `${ESTUDO}/LinguaEstrangeira`,
-      },
-      {
-        icon: Artes,
-        alt: "artes",
-        text: "Artes",
-        link: `${ESTUDO}/Artes`,
-      },
+      { icon: Gramatica, alt: "língua portuguesa", text: "Língua Portuguesa", link: `${ESTUDO}/LinguaPortuguesa` },
+      { icon: Ingles, alt: "língua estrangeira", text: "Língua Estrangeira", link: `${ESTUDO}/LinguaEstrangeira` },
+      { icon: Artes, alt: "artes", text: "Artes", link: `${ESTUDO}/Artes` },
     ],
   },
   {
@@ -228,24 +307,9 @@ export const dashCardMenuItems: DashCardMenu[] = [
     image: NaturezaImg,
     alt: "Natureza",
     subMenuList: [
-      {
-        icon: Biologia,
-        alt: "molécula de DNA",
-        text: "Biologia",
-        link: `${ESTUDO}/Biologia`,
-      },
-      {
-        icon: Fisica,
-        alt: "risco biológico",
-        text: "Física",
-        link: `${ESTUDO}/Fisica`,
-      },
-      {
-        icon: Quimica,
-        alt: "quimica",
-        text: "Quimica",
-        link: `${ESTUDO}/Quimica`,
-      },
+      { icon: Biologia, alt: "molécula de DNA", text: "Biologia", link: `${ESTUDO}/Biologia` },
+      { icon: Fisica, alt: "risco biológico", text: "Física", link: `${ESTUDO}/Fisica` },
+      { icon: Quimica, alt: "quimica", text: "Quimica", link: `${ESTUDO}/Quimica` },
     ],
   },
   {
@@ -255,36 +319,11 @@ export const dashCardMenuItems: DashCardMenu[] = [
     image: HumanasImg,
     alt: "Humanas",
     subMenuList: [
-      {
-        icon: Historia,
-        alt: "História",
-        text: "História",
-        link: `${ESTUDO}/Historia`,
-      },
-      {
-        icon: Geografia,
-        alt: "Geografia",
-        text: "Geografia",
-        link: `${ESTUDO}/Geografia`,
-      },
-      {
-        icon: Filosofia,
-        alt: "Filosofia",
-        text: "Filosofia",
-        link: `${ESTUDO}/Filosofia`,
-      },
-      {
-        icon: Sociologia,
-        alt: "Sociologia",
-        text: "Sociologia",
-        link: `${ESTUDO}/Sociologia`,
-      },
-      {
-        icon: Atualidades,
-        alt: "atualidades",
-        text: "Atualidades",
-        link: `${ESTUDO}/Atualidades`,
-      },
+      { icon: Historia, alt: "História", text: "História", link: `${ESTUDO}/Historia` },
+      { icon: Geografia, alt: "Geografia", text: "Geografia", link: `${ESTUDO}/Geografia` },
+      { icon: Filosofia, alt: "Filosofia", text: "Filosofia", link: `${ESTUDO}/Filosofia` },
+      { icon: Sociologia, alt: "Sociologia", text: "Sociologia", link: `${ESTUDO}/Sociologia` },
+      { icon: Atualidades, alt: "atualidades", text: "Atualidades", link: `${ESTUDO}/Atualidades` },
     ],
   },
   {
@@ -294,28 +333,7 @@ export const dashCardMenuItems: DashCardMenu[] = [
     image: MatematicaImg,
     alt: "Matemática",
     subMenuList: [
-      {
-        icon: Matematica,
-        alt: "calculadora",
-        text: "Matemática",
-        link: `${ESTUDO}/Matematica`,
-      },
-    ],
-  },
-  {
-    id: 7,
-    bg: "bg-red",
-    title: "Cursinho",
-    image: IoSchool,
-    alt: "Cursinho",
-    subMenuList: [
-      {
-        icon: FaClipboardList,
-        alt: "processos seletivos",
-        text: "Inscrições",
-        link: `/dashboard/${REGISTRATION_MONITOR}`,
-        permissions: [Roles.visualizarMinhasInscricoes],
-      },
+      { icon: Matematica, alt: "calculadora", text: "Matemática", link: `${ESTUDO}/Matematica` },
     ],
   },
 ];

--- a/src/pages/dashContent/modals/managerMateria.tsx
+++ b/src/pages/dashContent/modals/managerMateria.tsx
@@ -1,0 +1,181 @@
+import { InputFactory } from "@/components/organisms/inputFactory";
+import { Button } from "@/components/ui/button";
+import { iconPresets, imagePresets } from "@/config/materiaPresets";
+import { MateriaDto } from "@/services/content/getMaterias";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import * as yup from "yup";
+import ModalTemplate, {
+  ModalProps,
+} from "../../../components/templates/modalTemplate";
+
+const enemAreaOptions = [
+  { value: "Linguagens", label: "Linguagens" },
+  { value: "Ciências Humanas", label: "Ciências Humanas" },
+  { value: "Ciências da Natureza", label: "Ciências da Natureza" },
+  { value: "Matemática", label: "Matemática" },
+];
+
+interface FormData {
+  nome: string;
+  enemArea: string;
+  icon: string;
+  image: string;
+}
+
+interface Props extends ModalProps {
+  materia?: MateriaDto | null;
+  onSubmit: (data: FormData) => Promise<void>;
+  isOpen: boolean;
+}
+
+const schema = yup.object().shape({
+  nome: yup.string().required("Nome é obrigatório"),
+  enemArea: yup.string().required("Área ENEM é obrigatória"),
+  icon: yup.string().default(""),
+  image: yup.string().default(""),
+});
+
+function PresetGrid({
+  presets,
+  selected,
+  onSelect,
+  size = "w-12 h-12",
+}: {
+  presets: Record<string, React.FunctionComponent<React.SVGProps<SVGSVGElement>>>;
+  selected: string;
+  onSelect: (key: string) => void;
+  size?: string;
+}) {
+  return (
+    <div className="grid grid-cols-5 gap-2">
+      {Object.entries(presets).map(([key, Svg]) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onSelect(key)}
+          className={`flex flex-col items-center p-2 rounded-md border-2 transition-all cursor-pointer ${
+            selected === key
+              ? "border-orange bg-orange/10"
+              : "border-gray-200 hover:border-gray-400"
+          }`}
+        >
+          <Svg className={size} />
+          <span className="text-[10px] text-gray-500 mt-1 truncate max-w-full">
+            {key}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ManagerMateria({ handleClose, materia, onSubmit, isOpen }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      nome: materia?.nome ?? "",
+      enemArea: materia?.enemArea ?? "Linguagens",
+      icon: materia?.icon ?? "",
+      image: materia?.image ?? "",
+    },
+  });
+
+  const selectedIcon = watch("icon");
+  const selectedImage = watch("image");
+
+  useEffect(() => {
+    register("nome");
+    register("enemArea");
+    register("icon");
+    register("image");
+  }, [register]);
+
+  useEffect(() => {
+    if (materia) {
+      setValue("nome", materia.nome);
+      setValue("enemArea", materia.enemArea);
+      setValue("icon", materia.icon ?? "");
+      setValue("image", materia.image ?? "");
+    }
+  }, [materia, setValue]);
+
+  const submit = (data: FormData) => {
+    onSubmit(data).then(() => handleClose!());
+  };
+
+  return (
+    <ModalTemplate
+      isOpen={isOpen}
+      handleClose={handleClose!}
+      className="bg-white w-full max-w-2xl p-6 rounded-md max-h-[90vh] overflow-y-auto"
+    >
+      <h2 className="text-lg font-semibold text-gray-700 mb-4">
+        {materia ? "Editar Matéria" : "Criar Nova Matéria"}
+      </h2>
+      <form onSubmit={handleSubmit(submit)} className="flex flex-col gap-4">
+        <InputFactory
+          id="nome"
+          type="text"
+          label="Nome"
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onChange={(e: any) => setValue("nome", e.target.value)}
+          error={errors.nome}
+          defaultValue={materia?.nome}
+        />
+
+        <InputFactory
+          id="enemArea"
+          type="select"
+          label="Área ENEM"
+          options={enemAreaOptions}
+          defaultValue={materia?.enemArea ?? "Linguagens"}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onChange={(e: any) => setValue("enemArea", e.target.value ?? e.value)}
+        />
+
+        <div>
+          <label className="text-sm font-medium text-gray-700 mb-2 block">
+            Ícone do Menu
+          </label>
+          <PresetGrid
+            presets={iconPresets}
+            selected={selectedIcon}
+            onSelect={(key) => setValue("icon", key)}
+          />
+        </div>
+
+        <div>
+          <label className="text-sm font-medium text-gray-700 mb-2 block">
+            Imagem da Página
+          </label>
+          <PresetGrid
+            presets={imagePresets}
+            selected={selectedImage}
+            onSelect={(key) => setValue("image", key)}
+            size="w-16 h-16"
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            variant="default"
+            className="bg-orange hover:bg-orange/80"
+            type="submit"
+          >
+            {materia ? "Salvar" : "Criar"}
+          </Button>
+        </div>
+      </form>
+    </ModalTemplate>
+  );
+}
+
+export default ManagerMateria;

--- a/src/pages/dashContent/modals/panelMateria.tsx
+++ b/src/pages/dashContent/modals/panelMateria.tsx
@@ -1,0 +1,188 @@
+import ModalConfirmCancel from "@/components/organisms/modalConfirmCancel";
+import { iconPresets } from "@/config/materiaPresets";
+import { useModals } from "@/hooks/useModal";
+import { MateriaCanDeleteResult } from "@/services/content/getMateriaCanDelete";
+import { MateriaDto } from "@/services/content/getMaterias";
+import { Button, IconButton } from "@mui/material";
+import Paper from "@mui/material/Paper";
+import Tooltip from "@mui/material/Tooltip";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { useEffect, useState } from "react";
+import { MdDeleteForever, MdModeEdit } from "react-icons/md";
+import ManagerMateria from "./managerMateria";
+
+interface Props {
+  materias: MateriaDto[];
+  onCreate: (data: {
+    nome: string;
+    enemArea: string;
+    icon: string;
+    image: string;
+  }) => Promise<void>;
+  onUpdate: (
+    id: string,
+    data: { nome?: string; enemArea?: string; icon?: string; image?: string },
+  ) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  /** Verifica se a matéria pode ser excluída (sem frentes/questões vinculadas). Se não for passado, o modal não exibe validação prévia. */
+  checkCanDelete?: (id: string) => Promise<MateriaCanDeleteResult>;
+}
+
+export function PanelMateria({
+  materias,
+  onCreate,
+  onUpdate,
+  onDelete,
+  checkCanDelete,
+}: Props) {
+  const [selected, setSelected] = useState<MateriaDto | null>(null);
+  const [canDeleteState, setCanDeleteState] = useState<MateriaCanDeleteResult | null>(null);
+
+  const modals = useModals(["editor", "confirmDelete"]);
+
+  useEffect(() => {
+    if (!modals.confirmDelete.isOpen || !selected || !checkCanDelete) {
+      setCanDeleteState(null);
+      return;
+    }
+    let cancelled = false;
+    checkCanDelete(selected._id)
+      .then((res) => {
+        if (!cancelled) setCanDeleteState(res);
+      })
+      .catch(() => {
+        if (!cancelled) setCanDeleteState({ canDelete: true, frentesCount: 0, questoesCount: 0 });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [modals.confirmDelete.isOpen, selected?._id, checkCanDelete]);
+
+  const columns: GridColDef[] = [
+    { field: "nome", headerName: "Nome", flex: 1 },
+    {
+      field: "enemArea",
+      headerName: "Área ENEM",
+      width: 180,
+    },
+    {
+      field: "icon",
+      headerName: "Ícone",
+      align: "center",
+      headerAlign: "center",
+      width: 80,
+      renderCell: (params) => {
+        const Svg = iconPresets[params.row.icon];
+        return Svg ? <Svg className="w-6 h-6" /> : <span>-</span>;
+      },
+    },
+    {
+      field: "actions",
+      headerName: "Ações",
+      align: "center",
+      headerAlign: "center",
+      width: 120,
+      renderCell: (params) => (
+        <div className="flex gap-2 justify-center">
+          <Tooltip title="Editar matéria">
+            <IconButton
+              onClick={() => {
+                setSelected(params.row as MateriaDto);
+                modals.editor.open();
+              }}
+            >
+              <MdModeEdit className="fill-gray-500 hover:fill-black" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Excluir matéria">
+            <IconButton
+              onClick={() => {
+                setSelected(params.row as MateriaDto);
+                modals.confirmDelete.open();
+              }}
+            >
+              <MdDeleteForever className="fill-redError opacity-50 hover:opacity-100" />
+            </IconButton>
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  const canDelete = canDeleteState?.canDelete !== false;
+  const blockReason = canDeleteState && !canDeleteState.canDelete ? canDeleteState.message : null;
+
+  const handleConfirmDelete = () => {
+    if (!selected || !canDelete) return;
+    onDelete(selected._id)
+      .then(() => {
+        modals.confirmDelete.close();
+        setSelected(null);
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="flex flex-col h-[500px] overflow-y-scroll scrollbar-hide select-none">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-semibold text-gray-700">Matérias</h3>
+        <Button
+          onClick={() => {
+            setSelected(null);
+            modals.editor.open();
+          }}
+        >
+          Criar Nova Matéria
+        </Button>
+      </div>
+      <Paper sx={{ height: "100%", overflow: "auto" }}>
+        <DataGrid
+          rows={materias}
+          columns={columns}
+          getRowId={(row) => row._id}
+          rowHeight={40}
+          sx={{ border: 0 }}
+        />
+      </Paper>
+
+      {modals.editor.isOpen && (
+        <ManagerMateria
+          isOpen={modals.editor.isOpen}
+          handleClose={() => {
+            modals.editor.close();
+            setSelected(null);
+          }}
+          materia={selected}
+          onSubmit={async (data) => {
+            if (selected) {
+              await onUpdate(selected._id, data);
+            } else {
+              await onCreate(data);
+            }
+          }}
+        />
+      )}
+
+      {modals.confirmDelete.isOpen && selected && (
+        <ModalConfirmCancel
+          isOpen={modals.confirmDelete.isOpen}
+          handleClose={() => {
+            modals.confirmDelete.close();
+            setSelected(null);
+          }}
+          handleConfirm={handleConfirmDelete}
+          className="bg-white p-8 rounded-md"
+          confirmDisabled={!canDelete}
+        >
+          {blockReason ? (
+            <p className="text-gray-600">{blockReason}</p>
+          ) : (
+            <p className="text-gray-600">
+              Tem certeza que deseja excluir a matéria &quot;{selected.nome}&quot;?
+            </p>
+          )}
+        </ModalConfirmCancel>
+      )}
+    </div>
+  );
+}

--- a/src/pages/dashContent/modals/settingsFrente.tsx
+++ b/src/pages/dashContent/modals/settingsFrente.tsx
@@ -6,15 +6,28 @@ import {
 } from "@/dtos/content/frenteDto";
 import { useToastAsync } from "@/hooks/useToastAsync";
 import { createFrente } from "@/services/content/createFrente";
+import {
+  createMateria,
+  CreateMateriaDto,
+} from "@/services/content/createMateria";
 import { deleteFrente } from "@/services/content/deleteFrente";
+import { deleteMateria } from "@/services/content/deleteMateria";
+import { getMateriaCanDelete } from "@/services/content/getMateriaCanDelete";
 import { getMaterias, MateriaDto } from "@/services/content/getMaterias";
 import { updateFrente } from "@/services/content/updateFrente";
+import {
+  updateMateria,
+  UpdateMateriaDto,
+} from "@/services/content/updateMateria";
 import { getSubjects } from "@/services/content/getSubjects";
 import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import ModalTemplate from "../../../components/templates/modalTemplate";
 import { useAuthStore } from "../../../store/auth";
 import { PanelFrente } from "./panelFrente";
+import { PanelMateria } from "./panelMateria";
+
+type Tab = "frentes" | "materias";
 
 interface Props {
   isOpen: boolean;
@@ -22,6 +35,7 @@ interface Props {
 }
 
 function SettingsFrente({ isOpen, handleClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("frentes");
   const [frentes, setFrentes] = useState<FrenteDto[]>([]);
   const [materiasList, setMateriasList] = useState<MateriaDto[]>([]);
   const [materiaSelected, setMateriaSelected] = useState<string>("");
@@ -33,11 +47,12 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
     data: { token },
   } = useAuthStore();
 
-  useEffect(() => {
+  const fetchMaterias = () => {
+    setLoading(true);
     getMaterias(token)
       .then((res) => {
         setMateriasList(res);
-        if (res.length > 0) {
+        if (res.length > 0 && !materiaSelected) {
           setMateriaSelected(res[0]._id);
         }
       })
@@ -45,9 +60,16 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
         toast.error(error.message);
       })
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchMaterias();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
 
-  const handleCreate = async (body: CreateFrenteDtoInput) => {
+  // --- Frente handlers ---
+
+  const handleCreateFrente = async (body: CreateFrenteDtoInput) => {
     const materiaId = body.materia ?? materiaSelected;
     await executeAsync({
       action: () => createFrente(body, token),
@@ -64,19 +86,18 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
           subjects: [],
         };
         setFrentes((prev) => [...prev, newFrente]);
-        // Atualizar lista de matérias com o novo ObjectId da frente (evita refetch)
         setMateriasList((prev) =>
           prev.map((m) =>
             m._id === materiaId
               ? { ...m, frentes: [...(m.frentes ?? []), newFrente] }
-              : m
-          )
+              : m,
+          ),
         );
       },
     });
   };
 
-  const handleUpdate = async (body: UpdateFrenteDto) => {
+  const handleUpdateFrente = async (body: UpdateFrenteDto) => {
     await executeAsync({
       action: () => updateFrente(body, token),
       loadingMessage: "Editando Frente ... ",
@@ -85,8 +106,10 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
       onSuccess: () => {
         setFrentes(
           frentes.map((frente) =>
-            (frente._id || frente.id) === body.id ? { ...frente, nome: body.name } : frente
-          )
+            (frente._id || frente.id) === body.id
+              ? { ...frente, nome: body.name }
+              : frente,
+          ),
         );
       },
     });
@@ -95,17 +118,13 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
   function updateSizeFrente(id: string, size: number) {
     const newFrentes = frentes.map((frente) => {
       if ((frente._id || frente.id) === id) {
-        return {
-          ...frente,
-          lenght: size,
-        };
+        return { ...frente, lenght: size };
       }
       return frente;
     });
     setFrentes(newFrentes);
   }
 
-  /** Remove a frente da lista local e da lista de matérias (usado ao excluir frente). */
   function removeFrenteFromMateriasList(frenteId: string) {
     const norm = (id: string) => (f: FrenteDto) => (f._id || f.id) === id;
     setFrentes((prev) => prev.filter((f) => !norm(frenteId)(f)));
@@ -113,7 +132,7 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
       prev.map((m) => ({
         ...m,
         frentes: (m.frentes ?? []).filter((f) => !norm(frenteId)(f)),
-      }))
+      })),
     );
   }
 
@@ -143,10 +162,62 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
       frentesRaw.map((f) =>
         getSubjects(f._id || f.id, token)
           .then((subjects) => ({ ...f, lenght: subjects.length, subjects }))
-          .catch(() => ({ ...f, lenght: 0, subjects: [] }))
-      )
+          .catch(() => ({ ...f, lenght: 0, subjects: [] })),
+      ),
     ).then(setFrentes);
   }, [materiaSelected, materiasList, token]);
+
+  // --- Materia handlers ---
+
+  const handleCreateMateria = async (data: CreateMateriaDto) => {
+    await executeAsync({
+      action: () => createMateria(data, token),
+      loadingMessage: "Criando matéria...",
+      successMessage: "Matéria criada com sucesso",
+      errorMessage: (error: Error) => error.message,
+      onSuccess: (res) => {
+        const newMateria: MateriaDto = {
+          _id: res._id,
+          nome: res.nome,
+          enemArea: res.enemArea,
+          icon: res.icon,
+          image: res.image,
+          frentes: [],
+        };
+        setMateriasList((prev) => [...prev, newMateria]);
+      },
+    });
+  };
+
+  const handleUpdateMateria = async (id: string, data: UpdateMateriaDto) => {
+    await executeAsync({
+      action: () => updateMateria(id, data, token),
+      loadingMessage: "Editando matéria...",
+      successMessage: "Matéria editada com sucesso",
+      errorMessage: (error: Error) => error.message,
+      onSuccess: () => {
+        setMateriasList((prev) =>
+          prev.map((m) => (m._id === id ? { ...m, ...data } : m)),
+        );
+      },
+    });
+  };
+
+  const handleDeleteMateria = async (id: string) => {
+    await executeAsync({
+      action: () => deleteMateria(id, token),
+      loadingMessage: "Excluindo matéria...",
+      successMessage: "Matéria excluída com sucesso",
+      errorMessage: (error: Error) => error.message,
+      onSuccess: () => {
+        setMateriasList((prev) => prev.filter((m) => m._id !== id));
+        if (materiaSelected === id) {
+          setMateriaSelected("");
+          setFrentes([]);
+        }
+      },
+    });
+  };
 
   const materiasOptions = materiasList.map((m) => ({
     value: m._id,
@@ -160,11 +231,36 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
       className="bg-white w-[90vw] p-6 rounded-md max-h-[90vh]"
     >
       <div className="flex flex-col gap-6">
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200">
+          <button
+            type="button"
+            onClick={() => setActiveTab("frentes")}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === "frentes"
+                ? "border-b-2 border-orange text-orange"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            Frentes
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab("materias")}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === "materias"
+                ? "border-b-2 border-orange text-orange"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            Matérias
+          </button>
+        </div>
+
         {loading ? (
           <span className="text-gray-500">Carregando matérias...</span>
-        ) : (
+        ) : activeTab === "frentes" ? (
           <>
-            {/* Seleção de matéria */}
             <InputFactory
               id="materia"
               type="select"
@@ -174,8 +270,6 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               onChange={(e: any) => setMateriaSelected(e.target.value)}
             />
-
-            {/* Painel Frentes e Temas */}
             <div className="h-full">
               <PanelFrente
                 frentes={frentes}
@@ -185,12 +279,20 @@ function SettingsFrente({ isOpen, handleClose }: Props) {
                   materiasList.find((m) => m._id === materiaSelected)?.nome ??
                   ""
                 }
-                onCreate={handleCreate}
-                onUpdate={handleUpdate}
+                onCreate={handleCreateFrente}
+                onUpdate={handleUpdateFrente}
                 onDelete={handleDeleteFrente}
               />
             </div>
           </>
+        ) : (
+          <PanelMateria
+            materias={materiasList}
+            onCreate={handleCreateMateria}
+            onUpdate={handleUpdateMateria}
+            onDelete={handleDeleteMateria}
+            checkCanDelete={(id) => getMateriaCanDelete(id, token)}
+          />
         )}
       </div>
     </ModalTemplate>

--- a/src/pages/materia/data.ts
+++ b/src/pages/materia/data.ts
@@ -17,53 +17,24 @@ export interface MateriaPage {
 
 export type DataMateriaProps = Record<string, MateriaPage>;
 
+// Indexado por slug (usado no fallback) e por nome da matéria (para resolver pelo nome da API)
 export const dataMateria: DataMateriaProps = {
-  LinguaPortuguesa: {
-    image: LPT,
-    label: "Língua Portuguesa",
-  },
-  LinguaEstrangeira: {
-    image: Grammar,
-    label: "Língua Estrangeira",
-  },
-  Artes: {
-    image: Literature,
-    label: "Artes",
-  },
-  Biologia: {
-    image: Biology,
-    label: "Biologia",
-  },
-  Fisica: {
-    image: Astronaut,
-    label: "Física",
-  },
-  Quimica: {
-    image: Science,
-    label: "Quimica",
-  },
-  Matematica: {
-    image: Math,
-    label: "Matemática",
-  },
-  Historia: {
-    image: History,
-    label: "História",
-  },
-  Geografia: {
-    image: Geo,
-    label: "Geografia",
-  },
-  Filosofia: {
-    image: Thoughts,
-    label: "Filosofia",
-  },
-  Sociologia: {
-    image: TakingEarth,
-    label: "Sociologia",
-  },
-  Atualidades: {
-    image: TakingEarth,
-    label: "Atualidades",
-  },
+  LinguaPortuguesa: { image: LPT, label: "Língua Portuguesa" },
+  "Língua Portuguesa": { image: LPT, label: "Língua Portuguesa" },
+  LinguaEstrangeira: { image: Grammar, label: "Língua Estrangeira" },
+  "Língua Estrangeira": { image: Grammar, label: "Língua Estrangeira" },
+  Artes: { image: Literature, label: "Artes" },
+  Biologia: { image: Biology, label: "Biologia" },
+  Fisica: { image: Astronaut, label: "Física" },
+  Física: { image: Astronaut, label: "Física" },
+  Quimica: { image: Science, label: "Quimica" },
+  Química: { image: Science, label: "Química" },
+  Matematica: { image: Math, label: "Matemática" },
+  Matemática: { image: Math, label: "Matemática" },
+  Historia: { image: History, label: "História" },
+  História: { image: History, label: "História" },
+  Geografia: { image: Geo, label: "Geografia" },
+  Filosofia: { image: Thoughts, label: "Filosofia" },
+  Sociologia: { image: TakingEarth, label: "Sociologia" },
+  Atualidades: { image: TakingEarth, label: "Atualidades" },
 };

--- a/src/pages/materia/index.tsx
+++ b/src/pages/materia/index.tsx
@@ -1,12 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import { getImagePreset } from "../../config/materiaPresets";
 import { CONTENT } from "../../routes/path";
 import { getFrentesWithContent } from "../../services/content/getFrentes";
-import { getMaterias } from "../../services/content/getMaterias";
+import { getMaterias, MateriaDto } from "../../services/content/getMaterias";
 import { useAuthStore } from "../../store/auth";
 import { Frente } from "../../types/content/frenteContent";
 import { dataMateria } from "./data";
+
+// ObjectId do MongoDB: 24 caracteres hexadecimais
+function isObjectId(value: string): boolean {
+  return /^[a-f\d]{24}$/i.test(value);
+}
 
 function Materia() {
   const { nomeMateria } = useParams();
@@ -17,11 +23,75 @@ function Materia() {
 
   const [frentes, setFrentes] = useState<Frente[]>([]);
   const [frenteSelected, setFrenteSelected] = useState<Frente>();
+  const [materiaInfo, setMateriaInfo] = useState<{
+    nome: string;
+    image?: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  } | null>(null);
 
-  const materiaPageInfo = nomeMateria ? dataMateria[nomeMateria] : undefined;
-  const Icon = materiaPageInfo?.image;
+  useEffect(() => {
+    if (!nomeMateria) return;
 
-  const tituloMateria = materiaPageInfo?.label || "";
+    if (isObjectId(nomeMateria)) {
+      // Rota por ID: busca frentes direto pelo ID e resolve nome via getMaterias
+      getMaterias(token)
+        .then((materias) => {
+          const materia = materias.find((m) => m._id === nomeMateria);
+          if (materia) {
+            const imageFromDb = getImagePreset(materia.image);
+            const pageInfo = dataMateria[materia.nome];
+            setMateriaInfo({
+              nome: materia.nome,
+              image: imageFromDb ?? pageInfo?.image,
+            });
+          }
+          return getFrentesWithContent(nomeMateria, token);
+        })
+        .then((res) => {
+          if (!res) {
+            setFrentes([]);
+            setFrenteSelected(undefined);
+            return;
+          }
+          setFrentes(res);
+          setFrenteSelected(res.length > 0 ? res[0] : undefined);
+        })
+        .catch((error: Error) => {
+          toast.error(error.message);
+        });
+    } else {
+      // Rota por slug (fallback): resolve via mapeamento estático
+      const pageInfo = dataMateria[nomeMateria];
+      const tituloMateria = pageInfo?.label || "";
+      setMateriaInfo({
+        nome: tituloMateria,
+        image: pageInfo?.image,
+      });
+
+      getMaterias(token)
+        .then((materias) => {
+          const materia = materias.find((m: MateriaDto) => m.nome === tituloMateria);
+          if (!materia) {
+            toast.error(`Matéria "${tituloMateria}" não encontrada`);
+            return;
+          }
+          return getFrentesWithContent(materia._id, token);
+        })
+        .then((res) => {
+          if (!res) {
+            setFrentes([]);
+            setFrenteSelected(undefined);
+            return;
+          }
+          setFrentes(res);
+          setFrenteSelected(res.length > 0 ? res[0] : undefined);
+        })
+        .catch((error: Error) => {
+          toast.error(error.message);
+        });
+    }
+  }, [nomeMateria, token]);
+
+  const Icon = materiaInfo?.image;
 
   const getFrenteCards = useCallback(() => {
     if (frentes.length === 0) return null;
@@ -99,34 +169,6 @@ function Materia() {
     );
   }, [frenteSelected]);
 
-  useEffect(() => {
-    getMaterias(token)
-      .then((materias) => {
-        const materia = materias.find((m) => m.nome === tituloMateria);
-        if (!materia) {
-          toast.error(`Matéria "${tituloMateria}" não encontrada`);
-          return;
-        }
-        return getFrentesWithContent(materia._id, token);
-      })
-      .then((res) => {
-        if (!res) {
-          setFrentes([]);
-          setFrenteSelected(undefined);
-          return;
-        }
-        setFrentes(res);
-        if (res.length > 0) {
-          setFrenteSelected(res[0]);
-        } else {
-          setFrenteSelected(undefined);
-        }
-      })
-      .catch((error: Error) => {
-        toast.error(error.message);
-      });
-  }, [tituloMateria, nomeMateria, token]);
-
   return (
     <div className="min-h-screen bg-gray-10 py-10 px-4">
       <div className="container mx-auto">
@@ -134,7 +176,7 @@ function Materia() {
       <div className="flex flex-col-reverse md:flex-row items-center justify-between gap-8">
         <div className="text-center md:text-left">
           <h1 className="text-3xl font-bold text-blue-900 mb-2">
-            Explore o mundo da {tituloMateria}
+            Explore o mundo da {materiaInfo?.nome || ""}
           </h1>
           <p className="text-gray-500 text-base">
             Escolha uma frente e um tema para começar seus estudos 🚀

--- a/src/services/content/createMateria.ts
+++ b/src/services/content/createMateria.ts
@@ -1,0 +1,31 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { materias } from "../urls";
+
+export interface CreateMateriaDto {
+  nome: string;
+  enemArea: string;
+  icon?: string;
+  image?: string;
+}
+
+export async function createMateria(
+  data: CreateMateriaDto,
+  token: string,
+): Promise<{ _id: string; nome: string; enemArea: string; icon?: string; image?: string }> {
+  const response = await fetchWrapper(materias, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  const res = await response.json();
+  if (response.status !== 200 && response.status !== 201) {
+    const msg = Array.isArray(res?.message)
+      ? res.message.join(", ")
+      : (res?.message ?? "Erro ao criar matéria");
+    throw new Error(msg);
+  }
+  return res;
+}

--- a/src/services/content/deleteMateria.ts
+++ b/src/services/content/deleteMateria.ts
@@ -1,0 +1,19 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { materias } from "../urls";
+
+export async function deleteMateria(
+  id: string,
+  token: string,
+): Promise<void> {
+  const response = await fetchWrapper(`${materias}/${id}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (response.status !== 200 && response.status !== 204) {
+    const res = await response.json();
+    throw new Error(res?.message ?? "Erro ao excluir matéria");
+  }
+}

--- a/src/services/content/getMateriaCanDelete.ts
+++ b/src/services/content/getMateriaCanDelete.ts
@@ -1,0 +1,27 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { materias } from "../urls";
+
+export interface MateriaCanDeleteResult {
+  canDelete: boolean;
+  frentesCount: number;
+  questoesCount: number;
+  message?: string;
+}
+
+export async function getMateriaCanDelete(
+  id: string,
+  token: string
+): Promise<MateriaCanDeleteResult> {
+  const response = await fetchWrapper(`${materias}/${id}/can-delete`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const res = await response.json();
+  if (response.status !== 200) {
+    throw new Error(res?.message ?? "Erro ao verificar se a matéria pode ser excluída");
+  }
+  return res;
+}

--- a/src/services/content/getMaterias.ts
+++ b/src/services/content/getMaterias.ts
@@ -6,6 +6,8 @@ export interface MateriaDto {
   _id: string;
   nome: string;
   enemArea: string;
+  icon?: string;
+  image?: string;
   frentes: FrenteDto[];
 }
 

--- a/src/services/content/getMateriasGroupedByArea.ts
+++ b/src/services/content/getMateriasGroupedByArea.ts
@@ -1,0 +1,28 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { materias } from "../urls";
+
+export interface MateriaGroupedItem {
+  _id: string;
+  nome: string;
+  icon?: string;
+  image?: string;
+}
+
+export interface AreaWithMaterias {
+  enemArea: string;
+  materias: MateriaGroupedItem[];
+}
+
+export async function getMateriasGroupedByArea(): Promise<AreaWithMaterias[]> {
+  const response = await fetchWrapper(`${materias}/grouped-by-area`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const res = await response.json();
+  if (response.status !== 200) {
+    throw new Error(`Erro ao buscar matérias agrupadas: ${res.message}`);
+  }
+  return res;
+}

--- a/src/services/content/updateMateria.ts
+++ b/src/services/content/updateMateria.ts
@@ -1,0 +1,31 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { materias } from "../urls";
+
+export interface UpdateMateriaDto {
+  nome?: string;
+  enemArea?: string;
+  icon?: string;
+  image?: string;
+}
+
+export async function updateMateria(
+  id: string,
+  data: UpdateMateriaDto,
+  token: string,
+): Promise<void> {
+  const response = await fetchWrapper(`${materias}/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (response.status !== 200) {
+    const res = await response.json();
+    const msg = Array.isArray(res?.message)
+      ? res.message.join(", ")
+      : (res?.message ?? "Erro ao editar matéria");
+    throw new Error(msg);
+  }
+}


### PR DESCRIPTION
Adiciona gerenciamento de matérias no dash de conteúdo, com criação/edição, sincronização com o menu acadêmico e validação visual de exclusão baseada nas regras do backend.

Made-with: Cursor