### PR TITLE
ci: add concurrency to cancel outdated develop workflows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,6 +15,10 @@ on:
     branches: ["develop"]
     types: [submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ---------------------------------------------------------------------------
   # CI: Valida build antes de permitir aprovação do PR


### PR DESCRIPTION
When multiple PRs merge to develop, only the latest pipeline runs. Previous in-progress runs are automatically cancelled.