### PR TITLE
ci: migrar deploy de produção para fluxo baseado em tags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "🔧 Manutenção"
+      labels:
+        - chore
+        - refactor
+        - dependencies
+    - title: "📝 Documentação"
+      labels:
+        - documentation
+    - title: "Outros"
+      labels:
+        - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,16 @@
 # =============================================================================
-# main - CI + Deploy Production
-# =============================================================================
-# CI: Valida build em PR (antes de permitir aprovação)
-# Deploy: Roda após aprovação do PR → deploy em produção
+# main - CI only (deploy é feito via tag no release.yml)
 # =============================================================================
 
-name: main
+name: CI Main
 
 on:
   pull_request:
-    branches: ["main"]
-    types: [opened, synchronize, reopened, closed]
-  pull_request_review:
-    branches: ["main"]
-    types: [submitted]
+    branches: ['main']
+    types: [opened, synchronize, reopened]
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # CI: Valida build antes de permitir aprovação do PR
-  # ---------------------------------------------------------------------------
   BUILD:
-    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     env:
       VITE_VCNAFACUL_ID: ${{ secrets.VITE_VCNAFACUL_ID }}
@@ -30,73 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
-          cache: "yarn"
+          node-version: 'lts/*'
+          cache: 'yarn'
       - name: Install depends
         run: yarn install --frozen-lockfile
       - name: Build app vCnafacul
         run: yarn build
-
-  # ---------------------------------------------------------------------------
-  # Deploy: Production (após aprovação do PR)
-  # ---------------------------------------------------------------------------
-  DEPLOY:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    env:
-      VITE_VCNAFACUL_ID: ${{ secrets.VITE_VCNAFACUL_ID }}
-      VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
-
-    steps:
-      # Checkout main (estado após o merge) para produção refletir sempre a branch main.
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: |
-          if [ -f .yarnrc.yml ] || { [ -f package.json ] && grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"yarn@[2-9]' package.json; }; then
-            echo "Yarn Berry detected"
-            corepack enable
-            yarn install --immutable
-          else
-            echo "Yarn Classic detected"
-            yarn install --frozen-lockfile
-          fi
-
-      - name: Build for Production
-        run: yarn build
-
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          echo -e "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null" >> ~/.ssh/config
-
-      - name: Deploy to Production
-        run: |
-          BASE_PATH="domains/vcnafacul.com.br/public_html"
-
-          rsync -avz --delete \
-            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
-            ./dist/assets/ \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${BASE_PATH}/assets/
-
-          rsync -avz \
-            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
-            ./dist/index.html \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${BASE_PATH}/
-
-      - name: Remove SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key ~/.ssh/config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+# =============================================================================
+# release - Build, Deploy Production & Create GitHub Release
+# =============================================================================
+# Disparado por push de tag (ex: git tag v1.2.0 && git push origin v1.2.0)
+# 1. Build do frontend para produção
+# 2. Deploy via rsync (SSH) para Hostinger
+# 3. Cria Release no GitHub com changelog automático (PRs entre tags)
+# =============================================================================
+
+name: Release & Deploy Production
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  DEPLOY:
+    runs-on: ubuntu-latest
+    env:
+      VITE_VCNAFACUL_ID: ${{ secrets.VITE_VCNAFACUL_ID }}
+      VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: |
+          if [ -f .yarnrc.yml ] || { [ -f package.json ] && grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"yarn@[2-9]' package.json; }; then
+            echo "Yarn Berry detected"
+            corepack enable
+            yarn install --immutable
+          else
+            echo "Yarn Classic detected"
+            yarn install --frozen-lockfile
+          fi
+
+      - name: Build for Production
+        run: yarn build
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo -e "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+
+      - name: Deploy to Production
+        run: |
+          BASE_PATH="domains/vcnafacul.com.br/public_html"
+
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
+            ./dist/assets/ \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${BASE_PATH}/assets/
+
+          rsync -avz \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
+            ./dist/index.html \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${BASE_PATH}/
+
+      - name: Remove SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key ~/.ssh/config
+
+  CREATE_RELEASE:
+    needs: DEPLOY
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- main.yml agora faz apenas CI (build)
- Novo release.yml: disparado por push de tag v*, faz build, deploy via rsync e cria GitHub Release com changelog automático
- Novo .github/release.yml: categoriza PRs por labels no changelog