### PR TITLE
fix: limpar localStorage automaticamente a cada novo build

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,18 @@ import App from "./App.tsx";
 import "./index.css";
 import "primereact/resources/themes/md-light-indigo/theme.css";
 
+const PRESERVE_KEYS = ["lgpd_status", "lgpd_updated_at"];
+
+const storedVersion = localStorage.getItem("app-version");
+if (storedVersion !== __BUILD_VERSION__) {
+  const preserved = PRESERVE_KEYS.map((k) => [k, localStorage.getItem(k)]);
+  localStorage.clear();
+  preserved.forEach(([k, v]) => {
+    if (v != null) localStorage.setItem(k!, v);
+  });
+  localStorage.setItem("app-version", __BUILD_VERSION__);
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <div className="font-raleway">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="./svg" />
 /// <reference types="vite/client" />
+
+declare const __BUILD_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    __BUILD_VERSION__: JSON.stringify(Date.now().toString(36)),
+  },
   plugins: [react(), svgr()],
   resolve: {
     alias: {


### PR DESCRIPTION
Previne crashes causados por dados stale no localStorage após deploys. Um __BUILD_VERSION__ é gerado em cada build e comparado no boot; se diferente, limpa todo o localStorage preservando apenas o consentimento LGPD.