### PR TITLE
feat: widget redações para revisar respeita ambas permissões

### DIFF
--- a/src/pages/dashboard/components/RedacoesRevisarWidget.tsx
+++ b/src/pages/dashboard/components/RedacoesRevisarWidget.tsx
@@ -1,16 +1,31 @@
 import { useAuthStore } from '@/store/auth';
-import { getEssayCountForReview, EssayCountResponse } from '@/services/dashboard';
+import {
+  getEssayCountForReview,
+  getEssayCountForReviewAll,
+  EssayCountResponse,
+} from '@/services/dashboard';
 import { useWidgetData } from '../hooks/useWidgetData';
 import { WidgetShell } from './WidgetShell';
 import { WidgetIcon } from './WidgetIcon';
 import { Link } from 'react-router-dom';
-import { ESSAY_REVIEW_CURSINHO } from '@/routes/path';
+import { ESSAY_REVIEW_LIST, ESSAY_REVIEW_CURSINHO } from '@/routes/path';
+import { Roles } from '@/enums/roles/roles';
 import { FileEdit } from 'lucide-react';
 
 export function RedacoesRevisarWidget() {
   const token = useAuthStore((s) => s.data.token);
+  const permissao = useAuthStore((s) => s.data.permissao);
+
+  const isAdmin = !!permissao[Roles.revisarTodasRedacoes];
+
+  const fetcher = isAdmin
+    ? () => getEssayCountForReviewAll(token)
+    : () => getEssayCountForReview(token);
+
+  const reviewPath = isAdmin ? ESSAY_REVIEW_LIST : ESSAY_REVIEW_CURSINHO;
+
   const { data, isLoading, error, retry } =
-    useWidgetData<EssayCountResponse>(() => getEssayCountForReview(token));
+    useWidgetData<EssayCountResponse>(fetcher);
 
   return (
     <WidgetShell
@@ -32,7 +47,7 @@ export function RedacoesRevisarWidget() {
             </span>
           </div>
           <Link
-            to={ESSAY_REVIEW_CURSINHO}
+            to={reviewPath}
             className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-marine hover:underline"
           >
             Ir para revisão →

--- a/src/pages/dashboard/widgetRegistry.ts
+++ b/src/pages/dashboard/widgetRegistry.ts
@@ -45,7 +45,7 @@ export const widgetRegistry: WidgetDef[] = [
     id: 'redacoes-revisar',
     component: RedacoesRevisarWidget,
     profiles: ['collaborator'],
-    permissions: [Roles.revisarRedacoes],
+    permissions: [Roles.revisarRedacoes, Roles.revisarTodasRedacoes],
   },
   {
     id: 'questoes-pendentes',

--- a/src/services/dashboard/index.ts
+++ b/src/services/dashboard/index.ts
@@ -6,6 +6,7 @@ import {
   dashboardStudent,
   dashboardCollaborator,
   essayMyCursinhoCount,
+  essayAllCount,
   dashboardQuestoesPendentes,
 } from '../urls';
 
@@ -171,6 +172,24 @@ export async function getEssayCountForReview(
 ): Promise<EssayCountResponse> {
   const response = await fetchWrapper(
     `${essayMyCursinhoCount}?status=SUBMITTED`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  if (response.status !== 200)
+    throw new Error('Erro ao buscar contagem de redações');
+  return response.json();
+}
+
+export async function getEssayCountForReviewAll(
+  token: string,
+): Promise<EssayCountResponse> {
+  const response = await fetchWrapper(
+    `${essayAllCount}?status=SUBMITTED`,
     {
       method: 'GET',
       headers: {

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -128,6 +128,7 @@ export const essayMy = `${essay}/my`;
 export const essayMyStats = `${essayMy}/stats`;
 export const essaySettings = `${essay}/settings`;
 export const essayAll = `${essay}/all`;
+export const essayAllCount = `${essayAll}/count`;
 export const essayMyCursinho = `${essay}/my-cursinho`;
 export const essayPrepCourse = (prepCourseId: string) =>
   `${essay}/prep-course/${prepCourseId}`;


### PR DESCRIPTION
## Summary
- Widget "Redações para Revisar" agora aparece para `revisarRedacoes` OU `revisarTodasRedacoes`
- Admin (`revisarTodasRedacoes`): mostra contagem de todas as redações + link para tela admin
- Cursinho (`revisarRedacoes`): mostra contagem do cursinho + link para tela do cursinho
- `revisarTodasRedacoes` tem prioridade quando o usuário tem ambas as permissões

## Contexto
Antes, o widget só aparecia para colaboradores com `revisarRedacoes` e sempre apontava para a rota do cursinho. Admins com `revisarTodasRedacoes` não viam o card.

## Dependência
- Depende do PR de backend: https://github.com/vcnafacul/api-vcnafacul/pull/453

## Test plan
- [ ] Login como colaborador com `revisarRedacoes` → widget mostra contagem do cursinho + link para `/dashboard/revisao-redacoes-cursinho`
- [ ] Login como admin com `revisarTodasRedacoes` → widget mostra contagem total + link para `/dashboard/revisao-redacoes`
- [ ] Login como usuário sem nenhuma das permissões → widget não aparece
- [ ] Login com ambas as permissões → comportamento admin (prioridade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)