### PR TITLE
feat(home): links públicos no header logado + smooth scroll + mapa maior

### DIFF
--- a/src/components/organisms/map/index.tsx
+++ b/src/components/organisms/map/index.tsx
@@ -100,7 +100,7 @@ function Map() {
   return (
     <div id="map" className="relative w-full">
       <MapBox
-        className="z-30 h-[530px]"
+        className="z-30 h-[630px] lg:h-[750px]"
         zoom={7}
         markers={filteredMarkers}
         handleClickMarker={handleClickMarker}

--- a/src/components/templates/heroTemplate/index.tsx
+++ b/src/components/templates/heroTemplate/index.tsx
@@ -34,7 +34,7 @@ function HeroTemplate({ children, headerPosition = 'relative' }: HeroTemplatePro
     
 
     return (
-        <div ref={scrollContainerRef as LegacyRef<HTMLDivElement>} className="flex flex-col overflow-y-auto scrollbar-hide h-screen overflow-x-hidden">
+        <div ref={scrollContainerRef as LegacyRef<HTMLDivElement>} className="flex flex-col overflow-y-auto scrollbar-hide h-screen overflow-x-hidden scroll-smooth">
             <BaseTemplate solid={solid} position={headerPosition} headerShadow={false}>
                 <Hero />
                 { children }

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 @layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+  #about-us,
+  #map,
+  #supporters {
+    scroll-margin-top: 76px;
+  }
   :root {
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;

--- a/src/routes/baseRoutes.tsx
+++ b/src/routes/baseRoutes.tsx
@@ -1,15 +1,39 @@
 import { useEffect, useState } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { BaseTemplateContext } from "../context/baseTemplateContext";
 import { headerDash } from "../pages/dash/data";
 import { footer, header } from "../pages/home/data";
-import { NEWS } from "../routes/path";
+import { HOME_PATH, NEWS } from "../routes/path";
 import { getNews } from "../services/news/getNews";
 import { useAuthStore } from "../store/auth";
+import { ItemMenuProps } from "../components/molecules/menuItems";
+
+function mergeHeaderLinksForHome(
+  homeLinks: ItemMenuProps[],
+  dashLinks: ItemMenuProps[],
+): ItemMenuProps[] {
+  const seen = new Set<string>();
+  const merged: ItemMenuProps[] = [];
+  let nextId = 1;
+
+  for (const item of [...homeLinks, ...dashLinks]) {
+    const link = item.Home_Menu_Item_id.link;
+    if (seen.has(link)) continue;
+    seen.add(link);
+    merged.push({
+      ...item,
+      Home_Menu_Item_id: { ...item.Home_Menu_Item_id, id: nextId++ },
+    });
+  }
+  merged.pop();
+  return merged;
+}
 
 export function BaseRoutes() {
   const [hasNews, setHasNews] = useState<boolean | null>(null);
   const token = useAuthStore((s) => s.data.token);
+  const { pathname } = useLocation();
+  const isHome = pathname === HOME_PATH;
 
   useEffect(() => {
     getNews()
@@ -17,7 +41,14 @@ export function BaseRoutes() {
       .catch(() => setHasNews(false));
   }, []);
 
-  const basePageLinks = token ? headerDash.pageLinks : header.pageLinks;
+  let basePageLinks: ItemMenuProps[];
+  if (!token) {
+    basePageLinks = header.pageLinks;
+  } else if (isHome) {
+    basePageLinks = mergeHeaderLinksForHome(header.pageLinks, headerDash.pageLinks);
+  } else {
+    basePageLinks = headerDash.pageLinks;
+  }
 
   const pageLinks =
     hasNews === false


### PR DESCRIPTION
## Summary

- **Header na Home logado**: links públicos (Quem Somos, Localize um Cursinho, Apoiadores) agora aparecem junto com os links do dashboard quando o usuário está autenticado E na rota `/`. Fora da Home, mantém apenas links do dashboard. Deslogado, inalterado.
- **Smooth scroll**: clicar em âncoras `/#about-us`, `/#map`, `/#supporters` desliza até a seção em vez de pular. Implementado via `scroll-smooth` no container de rolagem customizado do `heroTemplate` (não é `html` que rola) + `scroll-margin-top: 76px` nos alvos para compensar o header fixo.
- **Mapa mais alto em telas grandes**: altura responsiva (`h-[630px] lg:h-[750px]`) para melhor uso do espaço em Full HD.

## Arquivos alterados

- `src/routes/baseRoutes.tsx` — detecta Home via `useLocation`, `mergeHeaderLinksForHome()` dedup por `link` e remapeia ids sequencialmente
- `src/components/templates/heroTemplate/index.tsx` — adicionado `scroll-smooth` no container de overflow
- `src/index.css` — `scroll-margin-top` nos 3 alvos de âncora
- `src/components/organisms/map/index.tsx` — altura responsiva do `MapBox`

## Test plan

- [ ] `/` deslogado: header mostra apenas links públicos (inalterado)
- [ ] `/` logado: header mostra Quem Somos, Localize Cursinho, Apoiadores, Novidades, Dashboard, Simulados
- [ ] `/dashboard/*` logado: header mostra apenas Dashboard, Novidades, Simulados (inalterado)
- [ ] Clicar em Quem Somos / Localize Cursinho / Apoiadores na Home desliza até a seção
- [ ] Seção alvo fica abaixo do header (não escondida pelo header fixo de 76px)
- [ ] Filtro de News continua removendo o link quando não há novidades
- [ ] Mapa ocupa altura adequada em telas `lg` e maiores

🤖 Generated with [Claude Code](https://claude.com/claude-code)