### PR TITLE
feat(dash/simulado): adiciona filtros client-side nome/tipo/bloqueado

### DIFF
--- a/src/pages/dashSimulado/index.tsx
+++ b/src/pages/dashSimulado/index.tsx
@@ -1,4 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { FilterProps } from "../../components/atoms/filter";
+import { SelectProps } from "../../components/atoms/select";
+import { OptionProps } from "../../components/atoms/selectOption";
+import { ButtonProps } from "../../components/molecules/button";
 import { CardDash } from "../../components/molecules/cardDash";
 import DashCardTemplate from "../../components/templates/dashCardTemplate";
 import { DashCardContext } from "../../context/dashCardContext";
@@ -10,8 +14,23 @@ import { useAuthStore } from "../../store/auth";
 import { formatDate } from "../../utils/date";
 import { Paginate } from "../../utils/paginate";
 
+const BLOQUEADO_ALL = "all";
+const BLOQUEADO_BLOCKED = "blocked";
+const BLOQUEADO_UNBLOCKED = "unblocked";
+
+const bloqueadoOptions: OptionProps[] = [
+  { id: BLOQUEADO_ALL, name: "Todos" },
+  { id: BLOQUEADO_BLOCKED, name: "Bloqueados" },
+  { id: BLOQUEADO_UNBLOCKED, name: "Liberados" },
+];
+
 function DashSimulado() {
   const [simulados, setSimulados] = useState<ISimuladoDTO[]>([]);
+  const [nameFilter, setNameFilter] = useState<string>("");
+  const [tipoFilter, setTipoFilter] = useState<string>("");
+  const [bloqueadoFilter, setBloqueadoFilter] =
+    useState<string>(BLOQUEADO_ALL);
+  const [resetKey, setResetKey] = useState<number>(0);
   const {
     data: { token },
   } = useAuthStore();
@@ -66,19 +85,85 @@ function DashSimulado() {
     return await getSimulados(token, page, limitCards);
   };
 
+  const tipoOptions: OptionProps[] = useMemo(() => {
+    const names = new Set<string>();
+    simulados.forEach((s) => {
+      if (s.tipo?.nome) names.add(s.tipo.nome);
+    });
+    return [
+      { id: "", name: "Todos os tipos" },
+      ...Array.from(names)
+        .sort((a, b) => a.localeCompare(b))
+        .map((n) => ({ id: n, name: n })),
+    ];
+  }, [simulados]);
+
+  const filteredSimulados = useMemo(() => {
+    const term = nameFilter.trim().toLowerCase();
+    return simulados.filter((s) => {
+      if (term && !s.nome.toLowerCase().includes(term)) return false;
+      if (tipoFilter && s.tipo?.nome !== tipoFilter) return false;
+      if (bloqueadoFilter === BLOQUEADO_BLOCKED && !s.bloqueado) return false;
+      if (bloqueadoFilter === BLOQUEADO_UNBLOCKED && s.bloqueado) return false;
+      return true;
+    });
+  }, [simulados, nameFilter, tipoFilter, bloqueadoFilter]);
+
+  const filterProps: FilterProps = {
+    placeholder: "Buscar por nome",
+    filtrar: (e: React.ChangeEvent<HTMLInputElement>) =>
+      setNameFilter(e.target.value),
+    defaultValue: nameFilter,
+  };
+
+  const selectFiltes: SelectProps[] = [
+    {
+      options: tipoOptions,
+      defaultValue: tipoFilter,
+      setState: (value: string) => setTipoFilter(value),
+    },
+    {
+      options: bloqueadoOptions,
+      defaultValue: bloqueadoFilter,
+      setState: (value: string) => setBloqueadoFilter(value),
+    },
+  ];
+
+  const hasActiveFilters =
+    nameFilter !== "" || tipoFilter !== "" || bloqueadoFilter !== BLOQUEADO_ALL;
+
+  const buttons: ButtonProps[] = [
+    {
+      onClick: () => {
+        setNameFilter("");
+        setTipoFilter("");
+        setBloqueadoFilter(BLOQUEADO_ALL);
+        setResetKey((k) => k + 1);
+      },
+      typeStyle: "quaternary",
+      size: "small",
+      disabled: !hasActiveFilters,
+      children: "Limpar filtros",
+    },
+  ];
+
   return (
     <DashCardContext.Provider
       value={{
         title: "Simulados",
-        entities: simulados,
+        entities: filteredSimulados,
         setEntities: setSimulados,
         onClickCard: () => {},
         getMoreCards,
         cardTransformation,
         limitCards,
+        filterProps,
+        selectFiltes,
+        buttons,
+        totalItems: filteredSimulados.length,
       }}
     >
-      <DashCardTemplate />
+      <DashCardTemplate key={resetKey} />
     </DashCardContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Filtros client-side em `/dashboard/dash-simulado`: busca por nome, select de tipo (derivado dinamicamente de `simulados[].tipo.nome`), select de status bloqueado/liberado.
- Botao "Limpar filtros" com remount do template (`key={resetKey}`) para resetar estado interno de Filter/Select.
- Sem mudancas de backend; filtragem via `useMemo` sobre simulados carregados.
- `totalItems` reflete contagem apos filtro.

## Test plan
- [ ] Acessar /dashboard/dash-simulado e verificar lista carregando
- [ ] Digitar nome parcial -> cards filtram case-insensitive
- [ ] Selecionar tipo -> mostra so simulados daquele tipo
- [ ] Selecionar Bloqueados/Liberados -> filtra por status
- [ ] Combinar filtros -> intersecao correta
- [ ] Botao "Limpar filtros" -> reseta UI e exibe todos

Generated with [Claude Code](https://claude.com/claude-code)