### PR TITLE
feat(dash/provas): adiciona filtros client-side nome/edicao/aplicacao/ano/gabarito

### DIFF
--- a/src/pages/dashProvas/index.tsx
+++ b/src/pages/dashProvas/index.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
+import { FilterProps } from "../../components/atoms/filter";
+import { SelectProps } from "../../components/atoms/select";
+import { OptionProps } from "../../components/atoms/selectOption";
 import { ButtonProps } from "../../components/molecules/button";
 import { CardDash } from "../../components/molecules/cardDash";
 import DashCardTemplate from "../../components/templates/dashCardTemplate";
@@ -22,11 +25,23 @@ import ShowProva from "./modals/showProva";
 import { downloadSyncReportPdf } from "./utils/syncReportPdf";
 import { useModals } from "@/hooks/useModal";
 
+const EDICAO_ALL = "";
+const APLICACAO_ALL = "";
+const ANO_ALL = "";
+
 function DashProva() {
   const [provas, setProvas] = useState<Prova[]>([]);
   const [provaSelected, setProvaSelected] = useState<Prova | null>(null);
 
   const [tipoSimulado, setTipoSimulado] = useState<ITipoSimulado[]>();
+
+  const [nameFilter, setNameFilter] = useState<string>("");
+  const [edicaoFilter, setEdicaoFilter] = useState<string>(EDICAO_ALL);
+  const [aplicacaoFilter, setAplicacaoFilter] =
+    useState<string>(APLICACAO_ALL);
+  const [anoFilter, setAnoFilter] = useState<string>(ANO_ALL);
+  const [gabaritoOnly, setGabaritoOnly] = useState<boolean>(false);
+  const [resetKey, setResetKey] = useState<number>(0);
 
   const limitCards = 500;
 
@@ -128,7 +143,91 @@ function DashProva() {
     return await getProvas(token, page, limitCards);
   };
 
-   
+  const edicaoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<string>();
+    provas.forEach((p) => {
+      if (p.edicao) set.add(p.edicao);
+    });
+    return [
+      { id: EDICAO_ALL, name: "Todas edições" },
+      ...Array.from(set)
+        .sort((a, b) => a.localeCompare(b))
+        .map((v) => ({ id: v, name: v })),
+    ];
+  }, [provas]);
+
+  const aplicacaoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<number>();
+    provas.forEach((p) => {
+      if (p.aplicacao !== undefined && p.aplicacao !== null)
+        set.add(p.aplicacao);
+    });
+    return [
+      { id: APLICACAO_ALL, name: "Todas aplicações" },
+      ...Array.from(set)
+        .sort((a, b) => a - b)
+        .map((v) => ({ id: v.toString(), name: v.toString() })),
+    ];
+  }, [provas]);
+
+  const anoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<number>();
+    provas.forEach((p) => {
+      if (p.ano !== undefined && p.ano !== null) set.add(p.ano);
+    });
+    return [
+      { id: ANO_ALL, name: "Todos os anos" },
+      ...Array.from(set)
+        .sort((a, b) => b - a)
+        .map((v) => ({ id: v.toString(), name: v.toString() })),
+    ];
+  }, [provas]);
+
+  const filteredProvas = useMemo(() => {
+    const term = nameFilter.trim().toLowerCase();
+    return provas.filter((p) => {
+      if (term && !p.nome?.toLowerCase().includes(term)) return false;
+      if (edicaoFilter && p.edicao !== edicaoFilter) return false;
+      if (aplicacaoFilter && p.aplicacao?.toString() !== aplicacaoFilter)
+        return false;
+      if (anoFilter && p.ano?.toString() !== anoFilter) return false;
+      if (gabaritoOnly && !p.gabarito) return false;
+      return true;
+    });
+  }, [provas, nameFilter, edicaoFilter, aplicacaoFilter, anoFilter, gabaritoOnly]);
+
+  const filterProps: FilterProps = {
+    placeholder: "Buscar por nome",
+    filtrar: (e: React.ChangeEvent<HTMLInputElement>) =>
+      setNameFilter(e.target.value),
+    defaultValue: nameFilter,
+  };
+
+  const selectFiltes: SelectProps[] = [
+    {
+      options: edicaoOptions,
+      defaultValue: edicaoFilter,
+      setState: (value: string) => setEdicaoFilter(value),
+    },
+    {
+      options: aplicacaoOptions,
+      defaultValue: aplicacaoFilter,
+      setState: (value: string) => setAplicacaoFilter(value),
+    },
+    {
+      options: anoOptions,
+      defaultValue: anoFilter,
+      setState: (value: string) => setAnoFilter(value),
+    },
+  ];
+
+  const hasActiveFilters =
+    nameFilter !== "" ||
+    edicaoFilter !== EDICAO_ALL ||
+    aplicacaoFilter !== APLICACAO_ALL ||
+    anoFilter !== ANO_ALL ||
+    gabaritoOnly;
+
   const handleSync = () => {
     execute({
       action: () => startSync(token),
@@ -158,6 +257,15 @@ function DashProva() {
     });
   };
 
+  const clearFilters = () => {
+    setNameFilter("");
+    setEdicaoFilter(EDICAO_ALL);
+    setAplicacaoFilter(APLICACAO_ALL);
+    setAnoFilter(ANO_ALL);
+    setGabaritoOnly(false);
+    setResetKey((k) => k + 1);
+  };
+
   const buttons: ButtonProps[] = [
     {
       disabled: !permissao[Roles.cadastrarProvas],
@@ -183,22 +291,44 @@ function DashProva() {
       size: "small",
       children: "Nova Prova",
     },
+    {
+      disabled: !hasActiveFilters,
+      onClick: clearFilters,
+      typeStyle: "refused",
+      size: "small",
+      children: "Limpar filtros",
+    },
   ];
+
+  const GabaritoCheckbox = (
+    <label className="flex items-center gap-2 text-sm font-medium text-marine cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={gabaritoOnly}
+        onChange={(e) => setGabaritoOnly(e.target.checked)}
+        className="w-4 h-4 accent-marine cursor-pointer"
+      />
+      Só com gabarito
+    </label>
+  );
 
   return (
     <DashCardContext.Provider
       value={{
         title: dashProva.title,
-        entities: provas,
+        entities: filteredProvas,
         setEntities: setProvas,
         onClickCard,
         getMoreCards,
         cardTransformation,
         limitCards,
+        filterProps,
+        selectFiltes,
         buttons,
+        totalItems: filteredProvas.length,
       }}
     >
-      <DashCardTemplate />
+      <DashCardTemplate key={resetKey} customFilter={[GabaritoCheckbox]} />
       <ModalNewProva />
       <ModalShowProva />
     </DashCardContext.Provider>


### PR DESCRIPTION
## Summary
- Filtros client-side em `/dashboard/dash-provas`: busca por nome, selects de edicao/aplicacao/ano (derivados dinamicamente de provas carregadas) e checkbox "So com gabarito".
- Botao "Limpar filtros" com remount do template via `key={resetKey}` para resetar estado interno de Filter/Select.
- Sem mudancas de backend; filtragem via `useMemo` sobre provas carregadas.
- `totalItems` reflete contagem apos filtro.

## Test plan
- [ ] Acessar /dashboard/dash-provas e verificar lista carregando
- [ ] Digitar nome parcial -> cards filtram case-insensitive
- [ ] Selecionar edicao/aplicacao/ano -> filtra corretamente
- [ ] Marcar "So com gabarito" -> mostra apenas provas com gabarito preenchido
- [ ] Combinar filtros -> intersecao correta
- [ ] Botao "Limpar filtros" -> reseta UI e exibe todas

Generated with [Claude Code](https://claude.com/claude-code)