### PR TITLE
feat(collaborator): admin photo upload UI + R2 path encoding

### DIFF
--- a/src/components/organisms/supporters/index.tsx
+++ b/src/components/organisms/supporters/index.tsx
@@ -248,10 +248,13 @@ function Supporters() {
               `Erro ao carregar foto do colaborador ${volunteer.name}:`,
               error
             );
-            // Fallback para a URL do FTP caso falhe
-            photoUrls[
-              volunteer.image
-            ] = `${VITE_FTP_PROFILE}/${volunteer.image}`;
+            // Legacy keys (sem prefix) ainda no FTP. Novos uploads ficam só
+            // no R2 — sem fallback.
+            if (!volunteer.image.includes("/")) {
+              photoUrls[
+                volunteer.image
+              ] = `${VITE_FTP_PROFILE}/${volunteer.image}`;
+            }
           }
         }
       }

--- a/src/pages/managerCollaborator/index.tsx
+++ b/src/pages/managerCollaborator/index.tsx
@@ -265,6 +265,7 @@ export default function ManagerCollaborator() {
         }
         handleActive={handleChangeActive}
         handleDescription={handleDescription}
+        onPhotoUpdated={handlePhotoUpdated}
         openUpdateRole={() => {
           if (roles.length === 0) {
             toast.error("Não há funções cadastradas");
@@ -319,6 +320,24 @@ export default function ManagerCollaborator() {
       });
       setCollaborator(collaboratorAux);
     });
+  };
+
+  const handlePhotoUpdated = async (
+    collaboratorId: string,
+    newPhotoKey: string,
+  ) => {
+    setCollaborator((prev) =>
+      prev.map((c) =>
+        c.id === collaboratorId ? { ...c, photo: newPhotoKey } : c,
+      ),
+    );
+    const url = await loadCollaboratorPhoto(newPhotoKey);
+    setCollaboratorPhotos((prev) => ({ ...prev, [newPhotoKey]: url }));
+    setCollaboratorSelected((prev) =>
+      prev && prev.id === collaboratorId
+        ? { ...prev, photo: newPhotoKey }
+        : prev,
+    );
   };
 
   const handleDescription = async (id: string, description: string) => {

--- a/src/pages/managerCollaborator/index.tsx
+++ b/src/pages/managerCollaborator/index.tsx
@@ -6,7 +6,10 @@ import { changeActive } from "@/services/prepCourse/collaborator/change-active";
 import { changeDescription } from "@/services/prepCourse/collaborator/change-description";
 import { getCollaborator } from "@/services/prepCourse/collaborator/get-collaborator";
 import { getCollaboratorFrentesBatch } from "@/services/prepCourse/collaborator/get-collaborator-frentes-batch";
-import { getPhotoCollaborator } from "@/services/prepCourse/collaborator/get-photo";
+import {
+  getPhotoCollaborator,
+  isLegacyPhotoKey,
+} from "@/services/prepCourse/collaborator/get-photo";
 import { getRoles } from "@/services/prepCourse/getRoles";
 import { updateUserRole } from "@/services/roles/updateUserRole";
 import { useAuthStore } from "@/store/auth";
@@ -116,12 +119,15 @@ export default function ManagerCollaborator() {
   const loadCollaboratorPhoto = async (photoKey: string) => {
     try {
       const blob = await getPhotoCollaborator(photoKey);
-      const url = URL.createObjectURL(blob);
-      return url;
+      return URL.createObjectURL(blob);
     } catch (error) {
       console.error(`Erro ao carregar foto do colaborador:`, error);
-      // Fallback para a URL do FTP caso falhe
-      return `${VITE_FTP_PROFILE}${photoKey}`;
+      // Legacy keys (sem prefix /) ainda podem estar no FTP. Novos uploads
+      // (com prefix collaborators/) vivem só no R2 — sem fallback FTP.
+      if (isLegacyPhotoKey(photoKey)) {
+        return `${VITE_FTP_PROFILE}${photoKey}`;
+      }
+      return "";
     }
   };
 

--- a/src/pages/managerCollaborator/modals/showInfo.tsx
+++ b/src/pages/managerCollaborator/modals/showInfo.tsx
@@ -129,13 +129,19 @@ export function ShowInfo({
     >
       <div className="p-4 rounded-md overflow-y-auto scrollbar-hide h-4/5 sm:h-fit">
         <div className="flex flex-col sm:flex-row items-center sm:items-start gap-8">
-          {collaborator.photo && (
+          {(collaborator.photo || canEditPhotos) && (
             <div className="w-56 h-40 flex flex-col items-center">
-              <img
-                className="rounded-full object-cover shadow-md shadow-stone-500 w-40 h-40"
-                src={photoUrl || `${VITE_FTP_PROFILE}${collaborator.photo}`}
-                alt={collaborator.name}
-              />
+              {collaborator.photo ? (
+                <img
+                  className="rounded-full object-cover shadow-md shadow-stone-500 w-40 h-40"
+                  src={photoUrl || `${VITE_FTP_PROFILE}${collaborator.photo}`}
+                  alt={collaborator.name}
+                />
+              ) : (
+                <div className="rounded-full shadow-md shadow-stone-500 w-40 h-40 bg-zinc-200 flex items-center justify-center text-zinc-500 text-xs text-center px-2">
+                  Sem foto
+                </div>
+              )}
               {canEditPhotos && (
                 <>
                   <input
@@ -152,7 +158,7 @@ export function ShowInfo({
                     className="mt-2 w-40 font-light"
                     disabled={photoUploading}
                   >
-                    Trocar foto
+                    {collaborator.photo ? "Trocar foto" : "Adicionar foto"}
                   </Button>
                 </>
               )}

--- a/src/pages/managerCollaborator/modals/showInfo.tsx
+++ b/src/pages/managerCollaborator/modals/showInfo.tsx
@@ -4,11 +4,14 @@ import PropValue from "@/components/molecules/PropValue";
 import { InputFactory } from "@/components/organisms/inputFactory";
 import ModalTemplate from "@/components/templates/modalTemplate";
 import { Badge } from "@/components/ui/badge";
+import { Roles } from "@/enums/roles/roles";
+import { useToastAsync } from "@/hooks/useToastAsync";
+import { adminUploadPhotoCollaborator } from "@/services/prepCourse/collaborator/admin-upload-photo";
 import { Afinidade } from "@/types/partnerPrepCourse/afinidades";
 import { getColorFromName, getTextColorFromName } from "@/utils/getColorFromName";
 import { formatDate } from "@/utils/date";
 import { phoneMask } from "@/utils/phoneMask";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { getCollaboratorFrentesEnriched } from "@/services/prepCourse/collaborator/get-collaborator-frentes";
 import { useAuthStore } from "@/store/auth";
@@ -21,6 +24,10 @@ interface ModalProps {
   photoUrl?: string;
   handleActive: (id: string) => Promise<void>;
   handleDescription: (id: string, description: string) => Promise<void>;
+  onPhotoUpdated?: (
+    collaboratorId: string,
+    newPhotoKey: string,
+  ) => Promise<void> | void;
   openUpdateRole: () => void;
 }
 
@@ -45,6 +52,7 @@ export function ShowInfo({
   isOpen,
   handleActive,
   handleDescription,
+  onPhotoUpdated,
   openUpdateRole,
 }: ModalProps) {
   const [actived, setActived] = useState<boolean>(collaborator.actived);
@@ -54,8 +62,46 @@ export function ShowInfo({
   const [loading, setLoading] = useState<string>("Atualizar");
   const [afinidades, setAfinidades] = useState<Afinidade[]>([]);
   const [frentesLoading, setFrentesLoading] = useState(false);
-  const { data: { token } } = useAuthStore();
+  const [photoUploading, setPhotoUploading] = useState(false);
+  const { data } = useAuthStore();
+  const { token, permissao } = data;
+  const canEditPhotos = !!permissao?.[Roles.alterarPermissao];
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const executeAsync = useToastAsync();
   const VITE_FTP_PROFILE = import.meta.env.VITE_FTP_PROFILE;
+
+  const handlePhotoFileSelected = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Selecione um arquivo de imagem.");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("A imagem não pode passar de 5 MB.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    setPhotoUploading(true);
+    await executeAsync({
+      action: () =>
+        adminUploadPhotoCollaborator(collaborator.id, formData, token),
+      loadingMessage: "Atualizando foto...",
+      successMessage: "Foto atualizada!",
+      errorMessage: (err: Error) => err.message,
+      onSuccess: (newPhotoKey: string) => {
+        void onPhotoUpdated?.(collaborator.id, newPhotoKey);
+      },
+      onFinally: () => setPhotoUploading(false),
+    });
+  };
 
   useEffect(() => {
     if (!isOpen || !collaborator?.id || !token) return;
@@ -84,12 +130,32 @@ export function ShowInfo({
       <div className="p-4 rounded-md overflow-y-auto scrollbar-hide h-4/5 sm:h-fit">
         <div className="flex flex-col sm:flex-row items-center sm:items-start gap-8">
           {collaborator.photo && (
-            <div className="w-56 h-40">
+            <div className="w-56 h-40 flex flex-col items-center">
               <img
                 className="rounded-full object-cover shadow-md shadow-stone-500 w-40 h-40"
                 src={photoUrl || `${VITE_FTP_PROFILE}${collaborator.photo}`}
                 alt={collaborator.name}
               />
+              {canEditPhotos && (
+                <>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    onChange={handlePhotoFileSelected}
+                  />
+                  <Button
+                    onClick={() => fileInputRef.current?.click()}
+                    typeStyle="secondary"
+                    size="small"
+                    className="mt-2 w-40 font-light"
+                    disabled={photoUploading}
+                  >
+                    Trocar foto
+                  </Button>
+                </>
+              )}
             </div>
           )}
           <div className="flex flex-col gap-2 w-full">

--- a/src/services/prepCourse/collaborator/admin-upload-photo.ts
+++ b/src/services/prepCourse/collaborator/admin-upload-photo.ts
@@ -1,0 +1,22 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { collaborator } from "../../urls";
+
+export async function adminUploadPhotoCollaborator(
+  collaboratorId: string,
+  data: FormData,
+  token: string,
+): Promise<string> {
+  const response = await fetchWrapper(
+    `${collaborator}/${collaboratorId}/photo`,
+    {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${token}` },
+      body: data,
+    },
+  );
+  const res = await response.text();
+  if (response.status !== 200) {
+    throw new Error("Erro ao atualizar foto do colaborador");
+  }
+  return res;
+}

--- a/src/services/prepCourse/collaborator/admin-upload-photo.ts
+++ b/src/services/prepCourse/collaborator/admin-upload-photo.ts
@@ -1,5 +1,5 @@
-import fetchWrapper from "../../utils/fetchWrapper";
-import { collaborator } from "../../urls";
+import { collaborator } from "@/services/urls";
+import fetchWrapper from "@/utils/fetchWrapper";
 
 export async function adminUploadPhotoCollaborator(
   collaboratorId: string,

--- a/src/services/prepCourse/collaborator/get-photo.ts
+++ b/src/services/prepCourse/collaborator/get-photo.ts
@@ -1,12 +1,15 @@
 import { collaborator } from "@/services/urls";
 
 export async function getPhotoCollaborator(key: string): Promise<Blob> {
-  const response = await fetch(`${collaborator}/${key}/photo`);
+  const response = await fetch(
+    `${collaborator}/${encodeURIComponent(key)}/photo`,
+  );
 
-  const { buffer, contentType } = await response.json();
   if (response.status !== 200) {
     throw new Error("Erro ao buscar o arquivo");
   }
+
+  const { buffer, contentType } = await response.json();
 
   // Decodificar o buffer Base64 e criar um Blob
   const binaryString = atob(buffer); // Decodificar Base64
@@ -15,4 +18,8 @@ export async function getPhotoCollaborator(key: string): Promise<Blob> {
     binaryData[i] = binaryString.charCodeAt(i);
   }
   return new Blob([binaryData], { type: contentType });
+}
+
+export function isLegacyPhotoKey(key: string): boolean {
+  return !key.includes("/");
 }


### PR DESCRIPTION
## Summary

- New admin "Trocar foto" / "Adicionar foto" button in the collaborator details modal (`pages/managerCollaborator/modals/showInfo.tsx`), gated by `data.permissao[Roles.alterarPermissao]`. Validates type (`image/*`) and size (≤ 5 MB) on the client.
- New service `services/prepCourse/collaborator/admin-upload-photo.ts` calling `PATCH /collaborator/:id/photo`.
- Parent (`pages/managerCollaborator/index.tsx`) gains an `onPhotoUpdated` callback that updates row state and refreshes the displayed image.
- `getPhotoCollaborator` now URL-encodes the photo key so prefixed keys (`collaborators/<uuid>.jpg`) traverse the API route correctly.
- FTP fallback restricted to legacy keys (no `/`); new R2-uploaded photos never fall back to FTP.

Companion API PR: https://github.com/vcnafacul/api-vcnafacul/pull/467

Spec: `docs/superpowers/specs/2026-04-26-collaborator-photo-r2-cache-design.md`
Plan: `docs/superpowers/plans/2026-04-26-collaborator-photo-r2-cache.md`

## Test plan

- [ ] Log in as admin (with `alterar_permissao`); open Manager Colaborador → eye icon on a row → "Trocar foto"; pick a JPG/PNG ≤ 5 MB → confirm modal photo refreshes, new key starts with `collaborators/`, persists on reload
- [ ] Same flow on a collaborator with no photo → "Adicionar foto" button appears with placeholder
- [ ] Try a non-image file → clear error toast, no request
- [ ] Try a > 5 MB file → clear error toast, no request
- [ ] Log in as non-admin → button is hidden
- [ ] Home (`Voluntários` section) still renders photos for both legacy and new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)