### PR TITLE
feat: handle pending/failed simulado status in history UI

### DIFF
--- a/src/components/molecules/simulationHistoryCard/index.tsx
+++ b/src/components/molecules/simulationHistoryCard/index.tsx
@@ -12,7 +12,18 @@ interface SimulationHistoryCardProps {
   historico: HistoricoDTO;
 }
 
+const statusLabel: Record<string, string> = {
+  pending: "Processando...",
+  processing: "Processando...",
+  failed: "Erro ao processar",
+};
+
 function SimulationHistoryCard({ historico }: SimulationHistoryCardProps) {
+  const isPending = !historico.aproveitamento;
+  const aproveitamentoValue = isPending
+    ? statusLabel[historico.status ?? "pending"] ?? "Pendente"
+    : `${(historico.aproveitamento!.geral * 100).toFixed(2)}%`;
+
   return (
     <Link
       className="flex flex-wrap gap-4 bg-white border border-gray-100 border-t-0 rounded p-4 pb-6 pr-12 m-2.5 shadow-md justify-between relative"
@@ -30,7 +41,7 @@ function SimulationHistoryCard({ historico }: SimulationHistoryCardProps) {
       />
       <SimulationHistoryField
         field="Aproveitamento:"
-        value={`${(historico.aproveitamento.geral * 100).toFixed(2)}%`}
+        value={aproveitamentoValue}
         className="md:min-w-[200px]"
       />
       <div className="group absolute right-4 bottom-6">

--- a/src/components/organisms/simulationHistoryHeader/index.tsx
+++ b/src/components/organisms/simulationHistoryHeader/index.tsx
@@ -14,6 +14,7 @@ import {
   BookOpen,
   CheckCircle2,
   Clock,
+  Loader2,
   Target,
   TrendingUp,
   XCircle,
@@ -39,6 +40,42 @@ export function SimulationHistoryHeader({
   const finished =
     historic.simulado.tipo.quantidadeTotalQuestao ===
     historic.questoesRespondidas;
+
+  if (!historic.aproveitamento) {
+    const isFailed = historic.status === "failed";
+    return (
+      <Box sx={{ p: 3, minHeight: "100vh" }}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 3 }}>
+          <Typography variant="h4" sx={{ color: "white", fontWeight: "bold", display: "flex", gap: 1 }}>
+            <BookOpen className="h-8 w-8" />
+            Detalhes do Simulado
+          </Typography>
+          <Button onClick={() => navigate(`${DASH}/${SIMULADO_HISTORIES}`)} variant="outline" className="bg-white hover:bg-gray-100">
+            Voltar
+          </Button>
+        </Box>
+        <Paper elevation={3} sx={{ p: 4, borderRadius: 2, display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+          {isFailed ? (
+            <XCircle className="h-16 w-16 text-red-500" />
+          ) : (
+            <Loader2 className="h-16 w-16 text-blue-500 animate-spin" />
+          )}
+          <Typography variant="h5" fontWeight="bold" color={isFailed ? "error" : "primary"}>
+            {isFailed ? "Erro ao processar simulado" : "Processando resultados..."}
+          </Typography>
+          <Typography variant="body1" color="text.secondary" textAlign="center">
+            {isFailed
+              ? "Ocorreu um erro ao calcular seu aproveitamento. Por favor, tente novamente mais tarde ou entre em contato com o suporte."
+              : "Seu simulado está sendo processado. Os resultados estarão disponíveis em breve."}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {historic.simulado.tipo.nome} — {historic.questoesRespondidas} de{" "}
+            {historic.simulado.tipo.quantidadeTotalQuestao} questões respondidas
+          </Typography>
+        </Paper>
+      </Box>
+    );
+  }
 
   // Prepara dados do Radar por MATÉRIAS
   const radarDataMaterias = (historic.aproveitamento?.materias ?? []).map((m) => ({

--- a/src/components/organisms/simulationHistoryHeader/index.tsx
+++ b/src/components/organisms/simulationHistoryHeader/index.tsx
@@ -41,14 +41,13 @@ export function SimulationHistoryHeader({
     historic.questoesRespondidas;
 
   // Prepara dados do Radar por MATÉRIAS
-  const radarDataMaterias = historic.aproveitamento.materias.map((m) => ({
+  const radarDataMaterias = (historic.aproveitamento?.materias ?? []).map((m) => ({
     materia: m.nome,
     aproveitamento: parseFloat((m.aproveitamento * 100).toFixed(1)),
   }));
 
   // Prepara dados do Radar por FRENTES
-  // Extrai todas as frentes de todas as matérias
-  const radarDataFrente = historic.aproveitamento.materias.flatMap((materia) =>
+  const radarDataFrente = (historic.aproveitamento?.materias ?? []).flatMap((materia) =>
     materia.frentes.map((frente) => ({
       materia: `${materia.nome} - ${frente.nome}`,
       aproveitamento: parseFloat((frente.aproveitamento * 100).toFixed(1)),
@@ -87,7 +86,7 @@ export function SimulationHistoryHeader({
     },
   ];
 
-  const aproveitamentoGeral = (historic.aproveitamento.geral * 100).toFixed(1);
+  const aproveitamentoGeral = ((historic.aproveitamento?.geral ?? 0) * 100).toFixed(1);
   const totalQuestoes = historic.simulado.tipo.quantidadeTotalQuestao;
   const percentualAcertos = ((acertos / totalQuestoes) * 100).toFixed(1);
   const percentualErros = ((erros / totalQuestoes) * 100).toFixed(1);

--- a/src/dtos/historico/historicoDTO.ts
+++ b/src/dtos/historico/historicoDTO.ts
@@ -54,6 +54,8 @@ interface SimuladoHistoricoDTO {
   vezesRespondido: number;
 }
 
+export type HistoricoStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
 export interface HistoricoDTO {
   _id: string;
   usuario: string;
@@ -62,6 +64,7 @@ export interface HistoricoDTO {
   respostas: AnswerHistoricoDTO[];
   tempoRealizado: number;
   questoesRespondidas: number;
-  aproveitamento: AproveitamentoDTO;
+  aproveitamento?: AproveitamentoDTO;
+  status?: HistoricoStatus;
   createdAt: DateTime;
 }

--- a/src/pages/simulationHistories/components/simpleHistoryCard.tsx
+++ b/src/pages/simulationHistories/components/simpleHistoryCard.tsx
@@ -39,11 +39,14 @@ export function SimpleHistoryCard({
     historico.questoesRespondidas ===
     historico.simulado.tipo.quantidadeTotalQuestao;
 
-  const performanceColor = getPerformanceColor(historico.aproveitamento.geral);
+  const geral = historico.aproveitamento?.geral;
+  const performanceColor = geral != null
+    ? getPerformanceColor(geral)
+    : "from-gray-100 to-gray-200";
 
-  const performancePercentage = (historico.aproveitamento.geral * 100).toFixed(
-    2
-  );
+  const performancePercentage = geral != null
+    ? `${(geral * 100).toFixed(2)}%`
+    : historico.status === "failed" ? "Erro" : "Processando...";
 
   const formattedDate = DateTime.fromISO(
     historico.createdAt.toString()

--- a/src/pages/simulationHistory/index.tsx
+++ b/src/pages/simulationHistory/index.tsx
@@ -32,7 +32,8 @@ export function SimulationHistory() {
 
   const modals = useModals(["modalImage"]);
 
-  const getStatus = (answer: AnswerHistoricoDTO) => {
+  const getStatus = (answer: AnswerHistoricoDTO | undefined) => {
+    if (!answer) return QuestionBoxStatus.unread;
     if (answer.questao === questionSelected?._id)
       return QuestionBoxStatus.active;
     else if (!answer.alternativaEstudante) return QuestionBoxStatus.unread;
@@ -45,7 +46,7 @@ export function SimulationHistory() {
     const questionSelected = historic!.simulado.questoes[index];
     setQuestionSelected(questionSelected);
     setAnswerSelected(
-      historic!.respostas.find((r) => r.questao === questionSelected._id)!
+      historic!.respostas.find((r) => r.questao === questionSelected._id) ?? null
     );
   };
 
@@ -57,7 +58,7 @@ export function SimulationHistory() {
         .then((res) => {
           setHistoric(res);
           setQuestionSelected(res.simulado.questoes[0]);
-          setAnswerSelected(res!.respostas[0]);
+          setAnswerSelected(res.respostas[0] ?? null);
         })
         .catch((error: Error) => {
           toast.error(error.message);
@@ -87,6 +88,11 @@ export function SimulationHistory() {
   }, [questionSelected?.imageId, token]);
 
   if (!historic) return <></>;
+
+  if (!historic.aproveitamento) {
+    return <SimulationHistoryHeader historic={historic} />;
+  }
+
   return (
     <>
       <SimulateTemplate
@@ -96,7 +102,7 @@ export function SimulationHistory() {
           id: q._id,
           number: index,
           status: getStatus(
-            historic.respostas.find((r) => r.questao === q._id)!
+            historic.respostas.find((r) => r.questao === q._id)
           ),
         }))}
         legends={simulateMetricData.legends}


### PR DESCRIPTION
## Summary

- Guard `aproveitamento` optional access across history list cards and `simpleHistoryCard` — shows "Processando..." or "Erro ao processar" while async queue runs
- `SimulationHistoryHeader`: early-return error/loading state when `aproveitamento` is absent, preventing the `reduce of empty array` crash
- `SimulationHistory` page: skip rendering `SimulateTemplate` when historico has no `aproveitamento`, preventing `AlternativeHistorico` crash on null `answerSelected`
- `getStatus` in history detail page now accepts `undefined` answer and returns `unread` safely

## Test plan

- [ ] Submit a simulado and check history list while processing (should show "Processando...")
- [ ] Open detail page of a failed historico — should show error state instead of crashing
- [ ] Open detail page of a completed historico — full stats view renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)