### PR TITLE
feat(class-analytics): monthly evolution chart (Fase E)

### DIFF
--- a/src/components/molecules/classEvolutionChart/index.tsx
+++ b/src/components/molecules/classEvolutionChart/index.tsx
@@ -1,0 +1,55 @@
+import { LineChart } from "@mui/x-charts/LineChart";
+import { ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
+
+interface Props {
+  months: ClassMonthsList["months"];
+  selectedMonth: string | null;
+  onSelectMonth: (month: string) => void;
+}
+
+function formatMonth(yyyymm: string) {
+  const [y, m] = yyyymm.split("-");
+  const date = new Date(Date.UTC(Number(y), Number(m) - 1, 1));
+  return date
+    .toLocaleString("pt-BR", { month: "short", year: "2-digit" })
+    .replace(".", "");
+}
+
+export function ClassEvolutionChart({ months, selectedMonth, onSelectMonth }: Props) {
+  if (months.length === 0) return null;
+
+  const ordered = [...months].sort((a, b) => a.month.localeCompare(b.month));
+  const labels = ordered.map((m) => formatMonth(m.month));
+  const values = ordered.map((m) => Math.round(m.geral));
+  const selectedIndex = ordered.findIndex((m) => m.month === selectedMonth);
+
+  return (
+    <div
+      className="w-full"
+      aria-label="Evolução do desempenho geral da turma por mês"
+    >
+      <h3 className="text-base font-semibold mb-2">Evolução por mês</h3>
+      <LineChart
+        height={220}
+        xAxis={[{ data: labels, scaleType: "point" }]}
+        yAxis={[{ min: 0, max: 100 }]}
+        series={[{ data: values, label: "Geral (%)", showMark: true }]}
+        margin={{ left: 40, right: 16, top: 16, bottom: 32 }}
+        slotProps={{ legend: { hidden: true } }}
+        onAreaClick={(_, params) => {
+          const idx = params?.dataIndex;
+          if (idx != null && ordered[idx]) onSelectMonth(ordered[idx].month);
+        }}
+        onMarkClick={(_, params) => {
+          const idx = params?.dataIndex;
+          if (idx != null && ordered[idx]) onSelectMonth(ordered[idx].month);
+        }}
+      />
+      {selectedIndex >= 0 && (
+        <p className="text-sm text-gray-500">
+          Mês selecionado: {labels[selectedIndex]} ({values[selectedIndex]}%)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/classSimuladoAnalytics/index.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/index.tsx
@@ -10,6 +10,7 @@ import { SampleSizeBanner } from "./SampleSizeBanner";
 import { EmptyState } from "./EmptyState";
 import { MateriaRadar } from "@/components/molecules/materiaRadar";
 import { FrenteRadar } from "@/components/molecules/frenteRadar";
+import { ClassEvolutionChart } from "@/components/molecules/classEvolutionChart";
 
 interface Props {
   classId: string;
@@ -114,6 +115,15 @@ export function ClassSimuladoAnalytics({ classId, token }: Props) {
         />
       ) : (
         <>
+          <ClassEvolutionChart
+            months={list.months}
+            selectedMonth={selectedMonth}
+            onSelectMonth={(m) => {
+              setSelectedMonth(m);
+              setSelectedMateriaId(undefined);
+            }}
+          />
+
           <MonthPicker
             months={list.months}
             value={selectedMonth}


### PR DESCRIPTION
## Summary
Fase E (final) do turma-analytics-simulado — adiciona gráfico de linha de evolução mensal do geral da turma na aba Desempenho em Simulados.

- **Novo molecule** `classEvolutionChart` — usa `@mui/x-charts/LineChart` direto, ordena meses cronologicamente, exibe pontos com `showMark`, labels pt-BR ("Mar/26", "Abr/26").
- **Pontos clicáveis**: tanto `onAreaClick` quanto `onMarkClick` trocam o mês selecionado e disparam o `useEffect` de `getClassSimuladoByMonth` no orquestrador.
- **Reaproveita dados** — consome `ClassMonthsList.months[]` já carregado pela Fase C, sem nova chamada de rede.
- **Auto-omissão** — `months.length === 0` → componente retorna `null`.

## Test Plan
- [x] `npm run build` limpo (Vite production build OK)
- [x] `tsc --noEmit` zero erros
- [x] ESLint zero warnings nos arquivos novos
- [ ] Smoke manual em homol:
  - [ ] Turma com 5+ meses → linha contínua, ponto selecionado destacado
  - [ ] Clicar em um ponto → mês muda, radar atualiza
  - [ ] Turma com 1 mês → ponto único sem quebrar
  - [ ] Turma sem meses → gráfico não aparece
  - [ ] Locale pt-BR confirmado (Fev/26, Mar/26, Abr/26)

## Dependência
Pareia com api PR #478 (Fase D, fila/crons no backend). Fase C já mergeada (#593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)