### PR TITLE
fix(class-analytics): timezone label, percentual (fração→%) e toggle radar matéria/frente

### DIFF
--- a/src/components/molecules/classEvolutionChart/index.tsx
+++ b/src/components/molecules/classEvolutionChart/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 function formatMonth(yyyymm: string) {
   const [y, m] = yyyymm.split("-");
-  const date = new Date(Date.UTC(Number(y), Number(m) - 1, 1));
+  const date = new Date(Number(y), Number(m) - 1, 1);
   return date
     .toLocaleString("pt-BR", { month: "short", year: "2-digit" })
     .replace(".", "");

--- a/src/components/molecules/classEvolutionChart/index.tsx
+++ b/src/components/molecules/classEvolutionChart/index.tsx
@@ -1,5 +1,6 @@
 import { LineChart } from "@mui/x-charts/LineChart";
 import { ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
+import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   months: ClassMonthsList["months"];
@@ -20,7 +21,7 @@ export function ClassEvolutionChart({ months, selectedMonth, onSelectMonth }: Pr
 
   const ordered = [...months].sort((a, b) => a.month.localeCompare(b.month));
   const labels = ordered.map((m) => formatMonth(m.month));
-  const values = ordered.map((m) => Math.round(m.geral));
+  const values = ordered.map((m) => formatPercent(m.geral));
   const selectedIndex = ordered.findIndex((m) => m.month === selectedMonth);
 
   return (

--- a/src/components/molecules/frenteRadar/index.tsx
+++ b/src/components/molecules/frenteRadar/index.tsx
@@ -3,26 +3,48 @@ import { ClassMonthAnalytics } from "@/types/classAnalytics/classSimuladoAnalyti
 import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
-  materia: ClassMonthAnalytics["materias"][number];
+  materias: ClassMonthAnalytics["materias"];
+  title?: string;
 }
 
-export function FrenteRadar({ materia }: Props) {
-  if (materia.frentes.length === 0) {
+type FlatFrente = {
+  key: string;
+  nome: string;
+  materiaNome: string;
+  aproveitamento: number;
+  studentsContributing: number;
+};
+
+export function FrenteRadar({ materias, title }: Props) {
+  const flat: FlatFrente[] = materias.flatMap((m) =>
+    m.frentes.map((f) => ({
+      key: `${m.id}-${f.id}`,
+      nome: f.nome,
+      materiaNome: m.nome,
+      aproveitamento: f.aproveitamento,
+      studentsContributing: f.studentsContributing,
+    })),
+  );
+
+  if (flat.length === 0) {
     return (
       <p className="py-2 text-sm text-center text-gray-400">
-        Nenhuma frente com dados para {materia.nome}.
+        Nenhuma frente com dados.
       </p>
     );
   }
 
-  const radarData = materia.frentes.map((f) => ({
+  const multipleMaterias = materias.length > 1;
+  const heading = title ?? (multipleMaterias ? "Frentes" : `Frentes — ${materias[0].nome}`);
+
+  const radarData = flat.map((f) => ({
     frente: f.nome.length > 14 ? f.nome.slice(0, 14) + "…" : f.nome,
     aproveitamento: formatPercent(f.aproveitamento),
   }));
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row">
-      <div className="h-56 flex-1" aria-label={`Radar de frentes de ${materia.nome}`}>
+      <div className="h-56 flex-1" aria-label={`Radar de frentes${multipleMaterias ? "" : ` de ${materias[0].nome}`}`}>
         <RadarChart
           data={radarData}
           indexBy="frente"
@@ -31,21 +53,21 @@ export function FrenteRadar({ materia }: Props) {
         />
       </div>
       <div className="w-full sm:w-64">
-        <p className="mb-1 text-xs font-medium text-gray-500 uppercase">
-          Frentes — {materia.nome}
-        </p>
-        <table className="w-full text-sm" aria-label={`Tabela de frentes de ${materia.nome}`}>
+        <p className="mb-1 text-xs font-medium text-gray-500 uppercase">{heading}</p>
+        <table className="w-full text-sm" aria-label="Tabela de frentes">
           <thead>
             <tr className="text-left text-xs text-gray-400">
               <th className="pb-1 font-normal">Frente</th>
+              {multipleMaterias && <th className="pb-1 font-normal">Matéria</th>}
               <th className="pb-1 font-normal text-right">Aproveito.</th>
               <th className="pb-1 font-normal text-right">Alunos</th>
             </tr>
           </thead>
           <tbody>
-            {materia.frentes.map((f) => (
-              <tr key={f.id} className="hover:bg-gray-50">
+            {flat.map((f) => (
+              <tr key={f.key} className="hover:bg-gray-50">
                 <td className="py-1 pr-2">{f.nome}</td>
+                {multipleMaterias && <td className="py-1 pr-2 text-gray-500">{f.materiaNome}</td>}
                 <td className="py-1 text-right">{formatPercent(f.aproveitamento)}%</td>
                 <td className="py-1 text-right text-gray-400">n={f.studentsContributing}</td>
               </tr>

--- a/src/components/molecules/frenteRadar/index.tsx
+++ b/src/components/molecules/frenteRadar/index.tsx
@@ -1,5 +1,6 @@
 import { RadarChart } from "@/components/atoms/radarChart";
 import { ClassMonthAnalytics } from "@/types/classAnalytics/classSimuladoAnalytics";
+import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   materia: ClassMonthAnalytics["materias"][number];
@@ -16,7 +17,7 @@ export function FrenteRadar({ materia }: Props) {
 
   const radarData = materia.frentes.map((f) => ({
     frente: f.nome.length > 14 ? f.nome.slice(0, 14) + "…" : f.nome,
-    aproveitamento: Math.round(f.aproveitamento),
+    aproveitamento: formatPercent(f.aproveitamento),
   }));
 
   return (
@@ -45,7 +46,7 @@ export function FrenteRadar({ materia }: Props) {
             {materia.frentes.map((f) => (
               <tr key={f.id} className="hover:bg-gray-50">
                 <td className="py-1 pr-2">{f.nome}</td>
-                <td className="py-1 text-right">{Math.round(f.aproveitamento)}%</td>
+                <td className="py-1 text-right">{formatPercent(f.aproveitamento)}%</td>
                 <td className="py-1 text-right text-gray-400">n={f.studentsContributing}</td>
               </tr>
             ))}

--- a/src/components/molecules/materiaRadar/index.tsx
+++ b/src/components/molecules/materiaRadar/index.tsx
@@ -1,5 +1,6 @@
 import { RadarChart } from "@/components/atoms/radarChart";
 import { ClassMonthAnalytics } from "@/types/classAnalytics/classSimuladoAnalytics";
+import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   materias: ClassMonthAnalytics["materias"];
@@ -18,7 +19,7 @@ export function MateriaRadar({ materias, onSelectMateria, selectedMateriaId }: P
 
   const radarData = materias.map((m) => ({
     materia: m.nome.length > 12 ? m.nome.slice(0, 12) + "…" : m.nome,
-    aproveitamento: Math.round(m.aproveitamento),
+    aproveitamento: formatPercent(m.aproveitamento),
   }));
 
   return (
@@ -54,7 +55,7 @@ export function MateriaRadar({ materias, onSelectMateria, selectedMateriaId }: P
                 aria-pressed={selectedMateriaId === m.id}
               >
                 <td className="py-1 pr-2">{m.nome}</td>
-                <td className="py-1 text-right">{Math.round(m.aproveitamento)}%</td>
+                <td className="py-1 text-right">{formatPercent(m.aproveitamento)}%</td>
                 <td className="py-1 text-right text-gray-400">n={m.studentsContributing}</td>
               </tr>
             ))}

--- a/src/components/organisms/classSimuladoAnalytics/KpiHeader.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/KpiHeader.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Loader2, RefreshCw } from "lucide-react";
 import { ClassMonthAnalytics, ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
+import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   list: ClassMonthsList;
@@ -45,7 +46,7 @@ export function KpiHeader({ list, monthData, onRefresh, refreshing }: Props) {
           <Card>
             <CardContent className="pt-4">
               <p className="text-xs text-gray-500">Aproveitamento geral</p>
-              <p className="text-2xl font-bold">{Math.round(monthData.geral)}%</p>
+              <p className="text-2xl font-bold">{formatPercent(monthData.geral)}%</p>
             </CardContent>
           </Card>
           <Card>

--- a/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 function formatMonthLabel(month: string): string {
   const [y, m] = month.split("-");
-  const date = new Date(Date.UTC(Number(y), Number(m) - 1, 1));
+  const date = new Date(Number(y), Number(m) - 1, 1);
   return date.toLocaleString("pt-BR", { month: "long", year: "numeric" });
 }
 

--- a/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
@@ -1,5 +1,6 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
+import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   months: ClassMonthsList["months"];
@@ -25,7 +26,7 @@ export function MonthPicker({ months, value, onChange }: Props) {
         <SelectContent>
           {months.map((m) => (
             <SelectItem key={m.month} value={m.month}>
-              {formatMonthLabel(m.month)} — {m.studentsWithAtLeastOneCompletedAttempt} alunos | {Math.round(m.geral)}%
+              {formatMonthLabel(m.month)} — {m.studentsWithAtLeastOneCompletedAttempt} alunos | {formatPercent(m.geral)}%
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/organisms/classSimuladoAnalytics/index.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/index.tsx
@@ -25,6 +25,8 @@ export function ClassSimuladoAnalytics({ classId, token }: Props) {
   const [monthLoading, setMonthLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [selectedMateriaId, setSelectedMateriaId] = useState<string | undefined>(undefined);
+  const [view, setView] = useState<"materia" | "frente">("materia");
+  const [viewTouched, setViewTouched] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -43,10 +45,16 @@ export function ClassSimuladoAnalytics({ classId, token }: Props) {
     setMonthLoading(true);
     setMonthData(null);
     setSelectedMateriaId(undefined);
+    setViewTouched(false);
     getClassSimuladoByMonth(classId, selectedMonth, token)
       .then(setMonthData)
       .finally(() => setMonthLoading(false));
   }, [classId, selectedMonth, token]);
+
+  useEffect(() => {
+    if (viewTouched || !monthData) return;
+    setView(monthData.materias.length <= 1 ? "frente" : "materia");
+  }, [monthData, viewTouched]);
 
   const baselineGeneratedAt = monthData?.generatedAt ?? null;
 
@@ -142,12 +150,52 @@ export function ClassSimuladoAnalytics({ classId, token }: Props) {
           {!monthLoading && monthData && (
             <>
               <SampleSizeBanner monthData={monthData} totalStudents={list.totalStudents} />
-              <MateriaRadar
-                materias={monthData.materias}
-                onSelectMateria={setSelectedMateriaId}
-                selectedMateriaId={selectedMateriaId}
-              />
-              {selectedMateria && <FrenteRadar materia={selectedMateria} />}
+              {monthData.materias.length > 0 && (
+                <div className="flex items-center justify-end gap-1 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setView("materia");
+                      setViewTouched(true);
+                    }}
+                    className={`rounded-l border px-3 py-1 ${
+                      view === "materia"
+                        ? "bg-blue-50 border-blue-300 text-blue-700"
+                        : "bg-white border-gray-200 text-gray-500 hover:bg-gray-50"
+                    }`}
+                    aria-pressed={view === "materia"}
+                  >
+                    Por matéria
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setView("frente");
+                      setViewTouched(true);
+                    }}
+                    className={`-ml-px rounded-r border px-3 py-1 ${
+                      view === "frente"
+                        ? "bg-blue-50 border-blue-300 text-blue-700"
+                        : "bg-white border-gray-200 text-gray-500 hover:bg-gray-50"
+                    }`}
+                    aria-pressed={view === "frente"}
+                  >
+                    Por frente
+                  </button>
+                </div>
+              )}
+              {view === "materia" ? (
+                <>
+                  <MateriaRadar
+                    materias={monthData.materias}
+                    onSelectMateria={setSelectedMateriaId}
+                    selectedMateriaId={selectedMateriaId}
+                  />
+                  {selectedMateria && <FrenteRadar materias={[selectedMateria]} />}
+                </>
+              ) : (
+                <FrenteRadar materias={monthData.materias} />
+              )}
             </>
           )}
         </>

--- a/src/utils/formatPercent.ts
+++ b/src/utils/formatPercent.ts
@@ -1,0 +1,3 @@
+export function formatPercent(fraction: number): number {
+  return Math.round(fraction * 100);
+}


### PR DESCRIPTION
## Summary
3 ajustes na tela de analytics de simulado por turma, descobertos durante testes em homol:

- **Timezone off-by-one no label de mês**: `Date.UTC(...)` + `toLocaleString('pt-BR')` em BRT renderizava o mês anterior (ex.: `2026-01` virava "dezembro 2025"). Trocado por construtor local `new Date(y, m-1, 1)`.
- **Percentual exibindo 0 quando deveria mostrar a fração**: backend (ms-simulado) retorna `aproveitamento` como fração [0-1], frontend tratava como percentual [0-100]. Criado helper centralizado `formatPercent(fraction)` aplicado em 7 call sites (KpiHeader, MonthPicker, ClassEvolutionChart, MateriaRadar, FrenteRadar).
- **Toggle "Por matéria / Por frente" no radar**: com 1 matéria e N frentes (cenário comum em turmas pequenas), radar por matéria virava 1 ponto único. Agora há toggle no topo + default automático: ≤1 matéria abre em "Por frente", senão "Por matéria". O drilldown da MateriaRadar continua funcionando.

## Test Plan
- [x] Mês `2026-01` exibe "janeiro 2026" (não "dezembro 2025")
- [x] KPI "Aproveitamento geral" mostra `22%` quando payload é `0.21944...`
- [x] Cenário 1 matéria com 6 frentes: abre direto no radar de frentes mostrando os 6 nomes
- [x] Cenário 3+ matérias: abre no radar por matéria; clique drilldown segue funcionando
- [x] Toggle manual: usuário pode trocar entre as duas visões a qualquer momento

🤖 Generated with [Claude Code](https://claude.com/claude-code)