### PR TITLE
feat(support-chat): ajustes visuais e correções de lógica

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -80,11 +80,29 @@ export function ChatHeader({
           <div className="min-w-0 flex flex-col">
             <span className="font-semibold text-sm truncate">{title}</span>
             <div className="flex items-center gap-1.5 text-[11px]">
-              {subtitle && (
-                <span className="px-1.5 py-0.5 rounded-full bg-white/10 truncate max-w-[240px]">
-                  {subtitle}
-                </span>
-              )}
+              {subtitle &&
+                subtitle.split(" · ").map((part, i) =>
+                  i === 0 && originPage ? (
+                    <a
+                      key={i}
+                      href={originPage}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-white/10 hover:bg-white/20 transition truncate max-w-[240px]"
+                      title={originPage}
+                    >
+                      <ExternalLink className="h-3 w-3 shrink-0" />
+                      <span className="truncate">{part}</span>
+                    </a>
+                  ) : (
+                    <span
+                      key={i}
+                      className="px-1.5 py-0.5 rounded-full bg-white/10 truncate max-w-[240px]"
+                    >
+                      {part}
+                    </span>
+                  ),
+                )}
               {status && (
                 <span
                   className={cn(
@@ -96,18 +114,6 @@ export function ChatHeader({
                 >
                   {isOpen ? "aberta" : "encerrada"}
                 </span>
-              )}
-              {originPage && (
-                <a
-                  href={originPage}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-white/10 hover:bg-white/20 transition truncate max-w-[200px]"
-                  title={originPage}
-                >
-                  <ExternalLink className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{originPage}</span>
-                </a>
               )}
               {device && (
                 <span

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import { ChatHeader } from "./ChatHeader";
 import { ChatInput } from "./ChatInput";
@@ -15,6 +16,7 @@ interface Props {
   originPage?: string;
   device?: string;
   browser?: string;
+  className?: string;
 }
 
 export function ChatLayout({
@@ -29,9 +31,10 @@ export function ChatLayout({
   originPage,
   device,
   browser,
+  className,
 }: Props) {
   return (
-    <Card className="flex flex-col h-full w-full overflow-hidden">
+    <Card className={cn("flex flex-col h-full w-full overflow-hidden", className)}>
       <ChatHeader
         conversationId={conversationId}
         title={title}

--- a/src/components/chat/SupportNotifier.tsx
+++ b/src/components/chat/SupportNotifier.tsx
@@ -4,10 +4,12 @@ import { toast } from "react-toastify";
 import { useChatContext } from "@/context/ChatProvider";
 import { useTabTitleUnread } from "@/hooks/useTabTitleUnread";
 import { DASH, DASH_SUPPORT } from "@/routes/path";
+import { getMyPartnerPrepId } from "@/services/chat/getMyPartnerPrepId";
 import {
   listenSupportInbox,
   type ConversationDoc,
 } from "@/services/firebase/conversations";
+import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 
 const INBOX_PATH = `${DASH}/${DASH_SUPPORT}`;
@@ -15,11 +17,17 @@ const INBOX_PATH = `${DASH}/${DASH_SUPPORT}`;
 export function SupportNotifier() {
   const { role } = useChatContext();
   const authed = useChatStore((s) => s.firebaseAuthed);
+  const jwt = useAuthStore((s) => s.data.token);
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [total, setTotal] = useState(0);
   const prevTotalRef = useRef<number | null>(null);
   const pathnameRef = useRef(pathname);
+
+  // undefined = ainda buscando; null = admin global (sem filtro); string = cursinho específico
+  const [resolvedPartnerPrepId, setResolvedPartnerPrepId] = useState<
+    string | null | undefined
+  >(undefined);
 
   useEffect(() => {
     pathnameRef.current = pathname;
@@ -27,8 +35,18 @@ export function SupportNotifier() {
 
   useTabTitleUnread(role === "support_agent" ? total : 0);
 
+  // Resolve o partnerPrepId real via API — o token Firebase não é confiável para
+  // agentes de cursinho pois o claim supportAgent sobrescreve o partnerPrepId.
+  useEffect(() => {
+    if (role !== "support_agent" || !authed || !jwt) return;
+    getMyPartnerPrepId(jwt)
+      .then((id) => setResolvedPartnerPrepId(id))
+      .catch(() => setResolvedPartnerPrepId(null));
+  }, [role, authed, jwt]);
+
   useEffect(() => {
     if (role !== "support_agent" || !authed) return;
+    if (resolvedPartnerPrepId === undefined) return;
 
     if (
       typeof Notification !== "undefined" &&
@@ -76,14 +94,14 @@ export function SupportNotifier() {
           n.close();
         };
       }
-    });
+    }, resolvedPartnerPrepId);
 
     return () => {
       unsub();
       prevTotalRef.current = null;
       setTotal(0);
     };
-  }, [role, authed, navigate]);
+  }, [role, authed, navigate, resolvedPartnerPrepId]);
 
   return null;
 }

--- a/src/components/chat/SupportNotifier.tsx
+++ b/src/components/chat/SupportNotifier.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useChatContext } from "@/context/ChatProvider";
 import { useTabTitleUnread } from "@/hooks/useTabTitleUnread";
-import { DASH, DASH_SUPPORT } from "@/routes/path";
+import { DASH, DASH_SUPPORT, DASH_PARTNER_SUPPORT } from "@/routes/path";
 import { getMyPartnerPrepId } from "@/services/chat/getMyPartnerPrepId";
 import {
   listenSupportInbox,
@@ -12,7 +12,10 @@ import {
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 
-const INBOX_PATH = `${DASH}/${DASH_SUPPORT}`;
+const INBOX_PATHS = [
+  `${DASH}/${DASH_SUPPORT}`,
+  `${DASH}/${DASH_PARTNER_SUPPORT}`,
+];
 
 export function SupportNotifier() {
   const { role } = useChatContext();
@@ -67,13 +70,16 @@ export function SupportNotifier() {
       if (prev === null) return;
       if (newTotal <= prev) return;
 
-      const onInboxPage = pathnameRef.current === INBOX_PATH;
+      const onInboxPage = INBOX_PATHS.includes(pathnameRef.current);
       if (!onInboxPage) {
         toast.info(
           "Um estudante enviou uma mensagem. Clique na notificação para vê-la.",
           {
             autoClose: 15000,
-            onClick: () => navigate(INBOX_PATH),
+            onClick: () =>
+              navigate(
+                resolvedPartnerPrepId ? INBOX_PATHS[1] : INBOX_PATHS[0],
+              ),
           },
         );
       }
@@ -90,7 +96,7 @@ export function SupportNotifier() {
         });
         n.onclick = () => {
           window.focus();
-          navigate(INBOX_PATH);
+          navigate(resolvedPartnerPrepId ? INBOX_PATHS[1] : INBOX_PATHS[0]);
           n.close();
         };
       }

--- a/src/components/support/PartnerSupportInbox.tsx
+++ b/src/components/support/PartnerSupportInbox.tsx
@@ -27,7 +27,7 @@ export function PartnerSupportInbox() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[calc(100vh-100px)]">
+      <div className="flex items-center justify-center h-[calc(100vh-76px)]">
         <span className="text-sm text-grey">Carregando...</span>
       </div>
     );
@@ -35,7 +35,7 @@ export function PartnerSupportInbox() {
 
   if (!partnerPrepId) {
     return (
-      <div className="flex flex-col items-center justify-center h-[calc(100vh-100px)] gap-3">
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-76px)] gap-3">
         <LuHeadset className="h-12 w-12 text-marine/30" />
         <span className="font-medium text-marine">Nenhum cursinho associado</span>
         <span className="text-sm text-grey max-w-xs text-center">

--- a/src/components/support/PartnerSupportInbox.tsx
+++ b/src/components/support/PartnerSupportInbox.tsx
@@ -1,30 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { LuMessageSquareDashed, LuHeadset, LuSearch } from "react-icons/lu";
-import { ChatLayout } from "@/components/chat/ChatLayout";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { useEffect, useState } from "react";
+import { LuHeadset } from "react-icons/lu";
 import { useChatContext } from "@/context/ChatProvider";
-import { useTabTitleUnread } from "@/hooks/useTabTitleUnread";
-import { markRead } from "@/services/chat/markRead";
 import { getMyPartnerPrepId } from "@/services/chat/getMyPartnerPrepId";
-import {
-  listenSupportInbox,
-  type ConversationDoc,
-} from "@/services/firebase/conversations";
 import { useAuthStore } from "@/store/auth";
-import { useChatStore } from "@/store/chatStore";
-import { ConversationListItem } from "@/pages/admin/support/ConversationListItem";
+import { useSupportInboxState } from "@/hooks/useSupportInboxState";
+import { SupportInboxView } from "./SupportInboxView";
 
 export function PartnerSupportInbox() {
-  const [convs, setConvs] = useState<ConversationDoc[]>([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
   const [partnerPrepId, setPartnerPrepId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const jwt = useAuthStore((s) => s.data.token);
   const { userId } = useChatContext();
-  const authed = useChatStore((s) => s.firebaseAuthed);
-  const autoSelectedRef = useRef(false);
 
   // Fetch the caller's cursinho ID directly from the backend — ignores token
   // claims precedence (supportAgent overrides partnerPrepId in the token).
@@ -36,57 +22,8 @@ export function PartnerSupportInbox() {
       .finally(() => setLoading(false));
   }, [jwt]);
 
-  useEffect(() => {
-    if (!authed || !partnerPrepId) return;
-    const unsub = listenSupportInbox(setConvs, partnerPrepId);
-    return unsub;
-  }, [authed, partnerPrepId]);
-
-  const totalUnread = useMemo(
-    () => convs.reduce((acc, c) => acc + (c.unreadCountSupport ?? 0), 0),
-    [convs],
-  );
-
-  const sorted = useMemo(() => {
-    const norm = search.trim().toLowerCase();
-    return [...convs]
-      .filter((c) => {
-        if (norm && !c.userName.toLowerCase().includes(norm)) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const aUn = (a.unreadCountSupport ?? 0) > 0 ? 1 : 0;
-        const bUn = (b.unreadCountSupport ?? 0) > 0 ? 1 : 0;
-        if (aUn !== bUn) return bUn - aUn;
-        const aTs = a.lastMessageAt?.toMillis?.() ?? 0;
-        const bTs = b.lastMessageAt?.toMillis?.() ?? 0;
-        return bTs - aTs;
-      });
-  }, [convs, search]);
-
-  const selected = useMemo(
-    () => convs.find((c) => c.id === selectedId) ?? null,
-    [convs, selectedId],
-  );
-
-  useEffect(() => {
-    if (autoSelectedRef.current) return;
-    if (selectedId) return;
-    const firstUnread = convs.find((c) => (c.unreadCountSupport ?? 0) > 0);
-    if (firstUnread) {
-      setSelectedId(firstUnread.id);
-      autoSelectedRef.current = true;
-    }
-  }, [convs, selectedId]);
-
-  useTabTitleUnread(totalUnread);
-
-  useEffect(() => {
-    if (!jwt || !selected) return;
-    if ((selected.unreadCountSupport ?? 0) > 0) {
-      markRead(jwt, selected.id).catch(() => {});
-    }
-  }, [selected, jwt]);
+  const { convs, sorted, selected, selectedId, setSelectedId, search, setSearch } =
+    useSupportInboxState(partnerPrepId);
 
   if (loading) {
     return (
@@ -100,9 +37,7 @@ export function PartnerSupportInbox() {
     return (
       <div className="flex flex-col items-center justify-center h-[calc(100vh-100px)] gap-3">
         <LuHeadset className="h-12 w-12 text-marine/30" />
-        <span className="font-medium text-marine">
-          Nenhum cursinho associado
-        </span>
+        <span className="font-medium text-marine">Nenhum cursinho associado</span>
         <span className="text-sm text-grey max-w-xs text-center">
           Sua conta não está vinculada a um cursinho parceiro.
         </span>
@@ -111,89 +46,17 @@ export function PartnerSupportInbox() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-100px)]">
-      <header className="bg-marine text-white px-5 py-3 flex items-center justify-between shadow-sm">
-        <div className="flex items-center gap-2">
-          <LuHeadset className="h-5 w-5 text-orange" />
-          <h1 className="font-raleway font-bold text-lg tracking-tight">
-            Suporte do Cursinho
-          </h1>
-        </div>
-        <div className="flex items-center gap-2 text-xs">
-          <span className="opacity-80">Conversas abertas</span>
-          <span className="bg-orange text-white font-bold rounded-full min-w-[24px] h-6 inline-flex items-center justify-center px-2">
-            {convs.length}
-          </span>
-        </div>
-      </header>
-      <div className="h-[3px] bg-custom-gradient" aria-hidden />
-      <div className="flex flex-1 min-h-0">
-        <aside className="w-80 border-r flex flex-col bg-backgroundGrey">
-          <div className="p-3 border-b bg-white">
-            <div className="relative">
-              <LuSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-grey" />
-              <Input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Buscar por nome..."
-                className="pl-8 h-9 text-sm"
-              />
-            </div>
-          </div>
-          <ScrollArea className="flex-1">
-            {sorted.map((c) => (
-              <ConversationListItem
-                key={c.id}
-                conv={c}
-                selected={selectedId === c.id}
-                onClick={() => setSelectedId(c.id)}
-              />
-            ))}
-            {sorted.length === 0 && (
-              <div className="flex flex-col items-center justify-center text-center px-6 py-16 gap-3">
-                <LuMessageSquareDashed className="h-12 w-12 text-marine/30" />
-                <span className="font-medium text-marine">
-                  {convs.length === 0
-                    ? "Nenhuma conversa aberta"
-                    : "Nenhum resultado"}
-                </span>
-                <span className="text-xs text-grey">
-                  {convs.length === 0
-                    ? "Quando um estudante pedir ajuda, aparecerá aqui."
-                    : "Ajuste o filtro ou a busca."}
-                </span>
-              </div>
-            )}
-          </ScrollArea>
-        </aside>
-        <main className="flex-1 bg-white">
-          {selected && userId ? (
-            <ChatLayout
-              conversationId={selected.id}
-              currentUserId={userId}
-              title={selected.userName}
-              subtitle={[selected.originLabel, selected.cursinhoName].filter(Boolean).join(" · ") || undefined}
-              onClose={() => setSelectedId(null)}
-              showAvatar
-              avatarSeed={selected.userId ?? selected.userName}
-              status={selected.status}
-              originPage={selected.metadata?.page}
-              device={selected.metadata?.device}
-              browser={selected.metadata?.browser}
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-8">
-              <LuHeadset className="h-14 w-14 text-marine/20" />
-              <span className="font-raleway font-semibold text-marine">
-                Selecione uma conversa
-              </span>
-              <span className="text-sm text-grey max-w-xs">
-                Escolha uma conversa na lista ao lado para começar a atender.
-              </span>
-            </div>
-          )}
-        </main>
-      </div>
-    </div>
+    <SupportInboxView
+      title="Suporte do Cursinho"
+      convs={convs}
+      sorted={sorted}
+      selected={selected}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      onClose={() => setSelectedId(null)}
+      search={search}
+      onSearchChange={setSearch}
+      userId={userId}
+    />
   );
 }

--- a/src/components/support/SupportInbox.tsx
+++ b/src/components/support/SupportInbox.tsx
@@ -1,95 +1,33 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { LuMessageSquareDashed, LuHeadset, LuSearch } from "react-icons/lu";
-import { ChatLayout } from "@/components/chat/ChatLayout";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useChatContext } from "@/context/ChatProvider";
-import { useTabTitleUnread } from "@/hooks/useTabTitleUnread";
-import { markRead } from "@/services/chat/markRead";
-import {
-  listenSupportInbox,
-  type ConversationDoc,
-} from "@/services/firebase/conversations";
-import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
-import { ConversationListItem } from "@/pages/admin/support/ConversationListItem";
 import { InitiateConversationDialog } from "@/pages/admin/support/InitiateConversationDialog";
+import { useSupportInboxState } from "@/hooks/useSupportInboxState";
+import { SupportInboxView } from "./SupportInboxView";
 
 export function SupportInbox() {
-  const [convs, setConvs] = useState<ConversationDoc[]>([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
   const [initiateOpen, setInitiateOpen] = useState(false);
-  const jwt = useAuthStore((s) => s.data.token);
   const { userId } = useChatContext();
-  const authed = useChatStore((s) => s.firebaseAuthed);
   const partnerPrepId = useChatStore((s) => s.partnerPrepId);
-  const autoSelectedRef = useRef(false);
-
-  useEffect(() => {
-    if (!authed) return;
-    const unsub = listenSupportInbox(setConvs, partnerPrepId);
-    return unsub;
-  }, [authed, partnerPrepId]);
-
-  const totalUnread = useMemo(
-    () => convs.reduce((acc, c) => acc + (c.unreadCountSupport ?? 0), 0),
-    [convs],
-  );
-
-  const sorted = useMemo(() => {
-    const norm = search.trim().toLowerCase();
-    return [...convs]
-      .filter((c) => {
-        if (norm && !c.userName.toLowerCase().includes(norm)) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const aUn = (a.unreadCountSupport ?? 0) > 0 ? 1 : 0;
-        const bUn = (b.unreadCountSupport ?? 0) > 0 ? 1 : 0;
-        if (aUn !== bUn) return bUn - aUn;
-        const aTs = a.lastMessageAt?.toMillis?.() ?? 0;
-        const bTs = b.lastMessageAt?.toMillis?.() ?? 0;
-        return bTs - aTs;
-      });
-  }, [convs, search]);
-
-  const selected = useMemo(
-    () => convs.find((c) => c.id === selectedId) ?? null,
-    [convs, selectedId],
-  );
-
-  useEffect(() => {
-    if (autoSelectedRef.current) return;
-    if (selectedId) return;
-    const firstUnread = convs.find((c) => (c.unreadCountSupport ?? 0) > 0);
-    if (firstUnread) {
-      setSelectedId(firstUnread.id);
-      autoSelectedRef.current = true;
-    }
-  }, [convs, selectedId]);
-
-  useTabTitleUnread(totalUnread);
-
-  useEffect(() => {
-    if (!jwt || !selected) return;
-    if ((selected.unreadCountSupport ?? 0) > 0) {
-      markRead(jwt, selected.id).catch(() => {});
-    }
-  }, [selected, jwt]);
+  const { convs, sorted, selected, selectedId, setSelectedId, search, setSearch } =
+    useSupportInboxState(partnerPrepId);
 
   return (
-    <div className="flex flex-col h-[calc(100vh-100px)]">
-      <header className="bg-marine text-white px-5 py-3 flex items-center justify-between shadow-sm">
-        <div className="flex items-center gap-2">
-          <LuHeadset className="h-5 w-5 text-orange" />
-          <h1 className="font-raleway font-bold text-lg tracking-tight">
-            Suporte
-          </h1>
-        </div>
-        <div className="flex items-center gap-2 text-xs">
-          {!partnerPrepId && (
+    <>
+      <SupportInboxView
+        title="Suporte"
+        convs={convs}
+        sorted={sorted}
+        selected={selected}
+        selectedId={selectedId}
+        onSelect={setSelectedId}
+        onClose={() => setSelectedId(null)}
+        search={search}
+        onSearchChange={setSearch}
+        userId={userId}
+        headerActions={
+          !partnerPrepId ? (
             <Button
               type="button"
               onClick={() => setInitiateOpen(true)}
@@ -97,81 +35,9 @@ export function SupportInbox() {
             >
               Iniciar conversa
             </Button>
-          )}
-          <span className="opacity-80">Conversas abertas</span>
-          <span className="bg-orange text-white font-bold rounded-full min-w-[24px] h-6 inline-flex items-center justify-center px-2">
-            {convs.length}
-          </span>
-        </div>
-      </header>
-      <div className="h-[3px] bg-custom-gradient" aria-hidden />
-      <div className="flex flex-1 min-h-0">
-        <aside className="w-80 border-r flex flex-col bg-backgroundGrey">
-          <div className="p-3 border-b bg-white">
-            <div className="relative">
-              <LuSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-grey" />
-              <Input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Buscar por nome..."
-                className="pl-8 h-9 text-sm"
-              />
-            </div>
-          </div>
-          <ScrollArea className="flex-1">
-            {sorted.map((c) => (
-              <ConversationListItem
-                key={c.id}
-                conv={c}
-                selected={selectedId === c.id}
-                onClick={() => setSelectedId(c.id)}
-              />
-            ))}
-            {sorted.length === 0 && (
-              <div className="flex flex-col items-center justify-center text-center px-6 py-16 gap-3">
-                <LuMessageSquareDashed className="h-12 w-12 text-marine/30" />
-                <span className="font-medium text-marine">
-                  {convs.length === 0
-                    ? "Nenhuma conversa aberta"
-                    : "Nenhum resultado"}
-                </span>
-                <span className="text-xs text-grey">
-                  {convs.length === 0
-                    ? "Quando um estudante pedir ajuda, aparecerá aqui."
-                    : "Ajuste o filtro ou a busca."}
-                </span>
-              </div>
-            )}
-          </ScrollArea>
-        </aside>
-        <main className="flex-1 bg-white">
-          {selected && userId ? (
-            <ChatLayout
-              conversationId={selected.id}
-              currentUserId={userId}
-              title={selected.userName}
-              subtitle={[selected.originLabel, selected.cursinhoName].filter(Boolean).join(" · ") || undefined}
-              onClose={() => setSelectedId(null)}
-              showAvatar
-              avatarSeed={selected.userId ?? selected.userName}
-              status={selected.status}
-              originPage={selected.metadata?.page}
-              device={selected.metadata?.device}
-              browser={selected.metadata?.browser}
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-8">
-              <LuHeadset className="h-14 w-14 text-marine/20" />
-              <span className="font-raleway font-semibold text-marine">
-                Selecione uma conversa
-              </span>
-              <span className="text-sm text-grey max-w-xs">
-                Escolha uma conversa na lista ao lado para começar a atender.
-              </span>
-            </div>
-          )}
-        </main>
-      </div>
+          ) : undefined
+        }
+      />
       {!partnerPrepId && (
         <InitiateConversationDialog
           open={initiateOpen}
@@ -179,6 +45,6 @@ export function SupportInbox() {
           onCreated={(id) => setSelectedId(id)}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/support/SupportInboxView.tsx
+++ b/src/components/support/SupportInboxView.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+import { LuMessageSquareDashed, LuHeadset, LuSearch } from "react-icons/lu";
+import { ChatLayout } from "@/components/chat/ChatLayout";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ConversationListItem } from "@/pages/admin/support/ConversationListItem";
+import type { ConversationDoc } from "@/services/firebase/conversations";
+
+interface Props {
+  title: string;
+  convs: ConversationDoc[];
+  sorted: ConversationDoc[];
+  selected: ConversationDoc | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  userId: string | null;
+  headerActions?: ReactNode;
+}
+
+export function SupportInboxView({
+  title,
+  convs,
+  sorted,
+  selected,
+  selectedId,
+  onSelect,
+  onClose,
+  search,
+  onSearchChange,
+  userId,
+  headerActions,
+}: Props) {
+  return (
+    <div className="flex flex-col h-[calc(100vh-100px)]">
+      <header className="bg-marine text-white px-5 py-3 flex items-center justify-between shadow-sm">
+        <div className="flex items-center gap-2">
+          <LuHeadset className="h-5 w-5 text-orange" />
+          <h1 className="font-raleway font-bold text-lg tracking-tight">
+            {title}
+          </h1>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          {headerActions}
+          <span className="opacity-80">Conversas abertas</span>
+          <span className="bg-orange text-white font-bold rounded-full min-w-[24px] h-6 inline-flex items-center justify-center px-2">
+            {convs.length}
+          </span>
+        </div>
+      </header>
+      <div className="h-[3px] bg-custom-gradient" aria-hidden />
+      <div className="flex flex-1 min-h-0">
+        <aside className="max-w-96 border-r flex flex-col bg-backgroundGrey">
+          <div className="p-3 border-b bg-white">
+            <div className="relative">
+              <LuSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-grey" />
+              <Input
+                value={search}
+                onChange={(e) => onSearchChange(e.target.value)}
+                placeholder="Buscar por nome..."
+                className="pl-8 h-9 text-sm"
+              />
+            </div>
+          </div>
+          <ScrollArea className="flex-1">
+            {sorted.map((c) => (
+              <ConversationListItem
+                key={c.id}
+                conv={c}
+                selected={selectedId === c.id}
+                onClick={() => onSelect(c.id)}
+              />
+            ))}
+            {sorted.length === 0 && (
+              <div className="flex flex-col items-center justify-center text-center px-6 py-16 gap-3">
+                <LuMessageSquareDashed className="h-12 w-12 text-marine/30" />
+                <span className="font-medium text-marine">
+                  {convs.length === 0
+                    ? "Nenhuma conversa aberta"
+                    : "Nenhum resultado"}
+                </span>
+                <span className="text-xs text-grey">
+                  {convs.length === 0
+                    ? "Quando um estudante pedir ajuda, aparecerá aqui."
+                    : "Ajuste o filtro ou a busca."}
+                </span>
+              </div>
+            )}
+          </ScrollArea>
+        </aside>
+        <main className="flex-1 bg-white">
+          {selected && userId ? (
+            <ChatLayout
+              conversationId={selected.id}
+              currentUserId={userId}
+              title={selected.userName}
+              subtitle={
+                [selected.originLabel, selected.cursinhoName]
+                  .filter(Boolean)
+                  .join(" · ") || undefined
+              }
+              onClose={onClose}
+              showAvatar
+              avatarSeed={selected.userId ?? selected.userName}
+              status={selected.status}
+              originPage={selected.metadata?.page}
+              device={selected.metadata?.device}
+              browser={selected.metadata?.browser}
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-8">
+              <LuHeadset className="h-14 w-14 text-marine/20" />
+              <span className="font-raleway font-semibold text-marine">
+                Selecione uma conversa
+              </span>
+              <span className="text-sm text-grey max-w-xs">
+                Escolha uma conversa na lista ao lado para começar a atender.
+              </span>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/support/SupportInboxView.tsx
+++ b/src/components/support/SupportInboxView.tsx
@@ -53,16 +53,14 @@ export function SupportInboxView({
       <div className="h-[3px] bg-custom-gradient" aria-hidden />
       <div className="flex flex-1 min-h-0">
         <aside className="max-w-96 border-r flex flex-col bg-backgroundGrey">
-          <div className="p-3 border-b bg-white">
-            <div className="relative">
-              <LuSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-grey" />
-              <Input
-                value={search}
-                onChange={(e) => onSearchChange(e.target.value)}
-                placeholder="Buscar por nome..."
-                className="pl-8 h-9 text-sm"
-              />
-            </div>
+          <div className="flex items-center gap-2 px-3 h-11 border-b bg-white shrink-0">
+            <LuSearch className="h-4 w-4 text-grey shrink-0" />
+            <Input
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Buscar por nome..."
+              className="flex-1 border-none shadow-none bg-transparent px-0 h-full text-sm focus-visible:ring-0 placeholder:text-grey"
+            />
           </div>
           <ScrollArea className="flex-1">
             {sorted.map((c) => (
@@ -95,6 +93,7 @@ export function SupportInboxView({
             <ChatLayout
               conversationId={selected.id}
               currentUserId={userId}
+              className="rounded-none"
               title={selected.userName}
               subtitle={
                 [selected.originLabel, selected.cursinhoName]

--- a/src/components/support/SupportInboxView.tsx
+++ b/src/components/support/SupportInboxView.tsx
@@ -34,7 +34,7 @@ export function SupportInboxView({
   headerActions,
 }: Props) {
   return (
-    <div className="flex flex-col h-[calc(100vh-100px)]">
+    <div className="flex flex-col h-[calc(100vh-76px)]">
       <header className="bg-marine text-white px-5 py-3 flex items-center justify-between shadow-sm">
         <div className="flex items-center gap-2">
           <LuHeadset className="h-5 w-5 text-orange" />

--- a/src/hooks/useSupportInboxState.ts
+++ b/src/hooks/useSupportInboxState.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTabTitleUnread } from "@/hooks/useTabTitleUnread";
+import { markRead } from "@/services/chat/markRead";
+import {
+  listenSupportInbox,
+  type ConversationDoc,
+} from "@/services/firebase/conversations";
+import { useAuthStore } from "@/store/auth";
+import { useChatStore } from "@/store/chatStore";
+
+export function useSupportInboxState(partnerPrepId: string | null) {
+  const [convs, setConvs] = useState<ConversationDoc[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const jwt = useAuthStore((s) => s.data.token);
+  const authed = useChatStore((s) => s.firebaseAuthed);
+  const autoSelectedRef = useRef(false);
+
+  useEffect(() => {
+    if (!authed) return;
+    const unsub = listenSupportInbox(setConvs, partnerPrepId);
+    return unsub;
+  }, [authed, partnerPrepId]);
+
+  const totalUnread = useMemo(
+    () => convs.reduce((acc, c) => acc + (c.unreadCountSupport ?? 0), 0),
+    [convs],
+  );
+
+  const sorted = useMemo(() => {
+    const norm = search.trim().toLowerCase();
+    return [...convs]
+      .filter((c) => !norm || c.userName.toLowerCase().includes(norm))
+      .sort((a, b) => {
+        const aUn = (a.unreadCountSupport ?? 0) > 0 ? 1 : 0;
+        const bUn = (b.unreadCountSupport ?? 0) > 0 ? 1 : 0;
+        if (aUn !== bUn) return bUn - aUn;
+        const aTs = a.lastMessageAt?.toMillis?.() ?? 0;
+        const bTs = b.lastMessageAt?.toMillis?.() ?? 0;
+        return bTs - aTs;
+      });
+  }, [convs, search]);
+
+  const selected = useMemo(
+    () => convs.find((c) => c.id === selectedId) ?? null,
+    [convs, selectedId],
+  );
+
+  useEffect(() => {
+    if (autoSelectedRef.current || selectedId) return;
+    const firstUnread = convs.find((c) => (c.unreadCountSupport ?? 0) > 0);
+    if (firstUnread) {
+      setSelectedId(firstUnread.id);
+      autoSelectedRef.current = true;
+    }
+  }, [convs, selectedId]);
+
+  useTabTitleUnread(totalUnread);
+
+  useEffect(() => {
+    if (!jwt || !selected) return;
+    if ((selected.unreadCountSupport ?? 0) > 0) {
+      markRead(jwt, selected.id).catch(() => {});
+    }
+  }, [selected, jwt]);
+
+  return { convs, sorted, selected, selectedId, setSelectedId, search, setSearch };
+}

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { LuHeadset } from "react-icons/lu";
 import { toast } from "react-toastify";
 import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ConfirmOpenDialog } from "@/components/chat/ConfirmOpenDialog";
@@ -14,6 +15,15 @@ export default function SupportPage() {
   const jwt = useAuthStore((s) => s.data.token);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [closedBySupport, setClosedBySupport] = useState(false);
+  const prevActiveRef = useRef(active);
+
+  useEffect(() => {
+    if (prevActiveRef.current && !active) {
+      setClosedBySupport(true);
+    }
+    prevActiveRef.current = active;
+  }, [active]);
 
   async function handleConfirm() {
     if (!jwt) return;
@@ -28,6 +38,7 @@ export default function SupportPage() {
         browser: "other",
       });
       setConfirmOpen(false);
+      setClosedBySupport(false);
     } catch (e) {
       const message =
         e instanceof Error ? e.message : "Falha ao abrir conversa";
@@ -45,7 +56,22 @@ export default function SupportPage() {
           currentUserId={userId}
           title="Suporte"
           status={active.status}
+          onClose={() => setClosedBySupport(true)}
         />
+      ) : closedBySupport ? (
+        <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-8">
+          <LuHeadset className="h-12 w-12 text-marine/30" />
+          <span className="font-raleway font-semibold text-marine">
+            Conversa encerrada
+          </span>
+          <span className="text-sm text-grey max-w-xs">
+            Esta conversa foi encerrada. Se precisar de mais ajuda, você pode
+            abrir uma nova conversa.
+          </span>
+          <Button onClick={() => setConfirmOpen(true)}>
+            Iniciar nova conversa
+          </Button>
+        </div>
       ) : (
         <div className="flex flex-col items-center justify-center h-full gap-4">
           <p>Você ainda não tem uma conversa aberta.</p>

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -44,6 +44,7 @@ export default function SupportPage() {
           conversationId={active.id}
           currentUserId={userId}
           title="Suporte"
+          status={active.status}
         />
       ) : (
         <div className="flex flex-col items-center justify-center h-full gap-4">

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -5,9 +5,18 @@ import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ConfirmOpenDialog } from "@/components/chat/ConfirmOpenDialog";
 import { Button } from "@/components/ui/button";
 import { useChatContext } from "@/context/ChatProvider";
-import { openConversation } from "@/services/chat/openConversation";
+import {
+  CooldownError,
+  openConversation,
+} from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`;
+}
 
 export default function SupportPage() {
   const active = useChatStore((s) => s.activeConversation);
@@ -16,6 +25,7 @@ export default function SupportPage() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [closedBySupport, setClosedBySupport] = useState(false);
+  const [cooldown, setCooldown] = useState<number | null>(null);
   const prevActiveRef = useRef(active);
 
   useEffect(() => {
@@ -24,6 +34,20 @@ export default function SupportPage() {
     }
     prevActiveRef.current = active;
   }, [active]);
+
+  useEffect(() => {
+    if (!cooldown || cooldown <= 0) return;
+    const id = setInterval(() => {
+      setCooldown((s) => {
+        if (s === null || s <= 1) {
+          clearInterval(id);
+          return null;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cooldown]);
 
   async function handleConfirm() {
     if (!jwt) return;
@@ -39,10 +63,14 @@ export default function SupportPage() {
       });
       setConfirmOpen(false);
       setClosedBySupport(false);
+      setCooldown(null);
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "Falha ao abrir conversa";
-      toast.error(message);
+      if (e instanceof CooldownError) {
+        setConfirmOpen(false);
+        setCooldown(e.retryAfterSeconds);
+      } else {
+        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      }
     } finally {
       setLoading(false);
     }
@@ -68,9 +96,20 @@ export default function SupportPage() {
             Esta conversa foi encerrada. Se precisar de mais ajuda, você pode
             abrir uma nova conversa.
           </span>
-          <Button onClick={() => setConfirmOpen(true)}>
-            Iniciar nova conversa
-          </Button>
+          {cooldown !== null ? (
+            <div className="flex flex-col items-center gap-1">
+              <span className="text-2xl font-bold font-mono text-marine">
+                {formatCountdown(cooldown)}
+              </span>
+              <span className="text-xs text-grey">
+                Aguarde para iniciar uma nova conversa
+              </span>
+            </div>
+          ) : (
+            <Button onClick={() => setConfirmOpen(true)}>
+              Iniciar nova conversa
+            </Button>
+          )}
         </div>
       ) : (
         <div className="flex flex-col items-center justify-center h-full gap-4">

--- a/src/services/chat/openConversation.ts
+++ b/src/services/chat/openConversation.ts
@@ -12,6 +12,12 @@ interface InscriptionContext {
   studentCourseId?: string;
 }
 
+export class CooldownError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super("cooldown");
+  }
+}
+
 export async function openConversation(
   jwt: string,
   metadata: ConversationMetadata,
@@ -28,9 +34,7 @@ export async function openConversation(
   });
   if (res.status === 429) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(
-      `Aguarde ${body.retryAfterSeconds ?? "alguns"} segundos para reabrir`,
-    );
+    throw new CooldownError(body.retryAfterSeconds ?? 60);
   }
   if (!res.ok) throw new Error("Falha ao abrir conversa");
   return res.json();


### PR DESCRIPTION
## Resumo

- Refatoração: extrai `SupportInboxView` e `useSupportInboxState` compartilhados entre admin e cursinho, eliminando duplicação
- Fix: aside com `max-w-96` evita que scrollbar cubra o `UnreadBadge`
- Feat: primeiro item do subtitle (ex: "Formulário de inscrição") vira link para o `originPage`; URL completa removida do header
- Fix: `SupportNotifier` filtra toasts por `partnerPrepId` do agente — cursinhos não recebem notificações de outros cursinhos
- Fix: toast suprimido quando agente já está na tela de suporte (admin ou cursinho); link do toast navega para o path correto
- Feat: estudante pode encerrar a conversa de suporte
- Feat: tela de "Conversa encerrada" exibida ao estudante quando a conversa é encerrada por qualquer lado
- Feat: countdown regressivo (MM:SS) durante cooldown — botão some e reaparece ao zerar; `CooldownError` tipado
- Fix: cooldown escopado por `userId + partnerPrepId` — encerrar com Cursinho A não bloqueia abertura com Cursinho B
- Fix: remove `rounded-xl` do `ChatLayout` nas telas de inbox via prop `className`
- Refactor: campo de busca ocupa toda a faixa do aside sem container interno
- Fix: altura da inbox corrigida de `100px` para `76px` (altura real do navbar)

## Test plan

- [ ] Abrir inbox de suporte como admin — lista filtra, badge visível, sem rounded no chat
- [ ] Abrir inbox de suporte como cursinho — mesma UX, toast só para conversas do próprio cursinho
- [ ] Encerrar conversa como agente → estudante vê tela de encerramento
- [ ] Encerrar conversa como estudante → tela de encerramento aparece
- [ ] Tentar abrir nova conversa durante cooldown → countdown aparece, botão some
- [ ] Aguardar countdown zerar → botão reaparece automaticamente
- [ ] Encerrar conversa com Cursinho A → abrir formulário do Cursinho B → sem bloqueio de cooldown
- [ ] Campo de busca ocupa toda a largura do aside
- [ ] Tela preenche até o fim sem espaço vazio no fundo

🤖 Generated with [Claude Code](https://claude.com/claude-code)