### PR TITLE
fix(class-analytics): polimento do dashboard de redação/simulado

### DIFF
--- a/src/components/molecules/classEvolutionChart/index.tsx
+++ b/src/components/molecules/classEvolutionChart/index.tsx
@@ -12,7 +12,7 @@ function formatMonth(yyyymm: string) {
   const [y, m] = yyyymm.split("-");
   const date = new Date(Number(y), Number(m) - 1, 1);
   return date
-    .toLocaleString("pt-BR", { month: "short", year: "2-digit" })
+    .toLocaleString("pt-BR", { month: "short" })
     .replace(".", "");
 }
 

--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -15,8 +15,70 @@ function formatMonth(yyyymm: string) {
     .replace(".", "");
 }
 
-const norm = (v: number, max: number) =>
-  Math.round((v / max) * 100 * 10) / 10;
+interface MiniLineProps {
+  id: string;
+  label: string;
+  color: string;
+  max: number;
+  values: number[];
+  labels: string[];
+  months: string[];
+  height: number;
+  onSelectMonth: (month: string) => void;
+}
+
+function MiniLine({
+  id,
+  label,
+  color,
+  max,
+  values,
+  labels,
+  months,
+  height,
+  onSelectMonth,
+}: MiniLineProps) {
+  return (
+    <div className="border rounded-md p-3 bg-white">
+      <div className="flex items-center gap-1.5 mb-1">
+        <span
+          className="inline-block w-3 h-3 rounded-sm"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        />
+        <h4 className="text-sm font-medium text-gray-800">{label}</h4>
+      </div>
+      <LineChart
+        height={height}
+        xAxis={[{ data: labels, scaleType: "point" }]}
+        yAxis={[{ min: 0, max }]}
+        series={[
+          {
+            id,
+            label,
+            color,
+            data: values,
+            showMark: true,
+            valueFormatter: (
+              v: number | null,
+              context: { dataIndex: number }
+            ) => `${v ?? values[context.dataIndex]} / ${max}`,
+          },
+        ]}
+        margin={{ left: 36, right: 12, top: 8, bottom: 28 }}
+        slotProps={{ legend: { hidden: true } }}
+        onAreaClick={(_, params) => {
+          const idx = params?.dataIndex;
+          if (idx != null && months[idx]) onSelectMonth(months[idx]);
+        }}
+        onMarkClick={(_, params) => {
+          const idx = params?.dataIndex;
+          if (idx != null && months[idx]) onSelectMonth(months[idx]);
+        }}
+      />
+    </div>
+  );
+}
 
 export function EssayEvolutionChart({
   months,
@@ -27,16 +89,18 @@ export function EssayEvolutionChart({
 
   const ordered = [...months].sort((a, b) => a.month.localeCompare(b.month));
   const labels = ordered.map((m) => formatMonth(m.month));
+  const monthKeys = ordered.map((m) => m.month);
   const selectedIndex = ordered.findIndex((m) => m.month === selectedMonth);
 
-  const seriesDefs = [
-    {
-      id: "geral",
-      label: "Geral",
-      color: "#02B2AF",
-      max: 1000,
-      values: ordered.map((m) => m.geral),
-    },
+  const geral = {
+    id: "geral",
+    label: "Geral",
+    color: "#02B2AF",
+    max: 1000,
+    values: ordered.map((m) => m.geral),
+  };
+
+  const competencias = [
     {
       id: "c1",
       label: "C1 — Norma",
@@ -74,66 +138,46 @@ export function EssayEvolutionChart({
     },
   ];
 
-  const series = seriesDefs.map(({ id, label, color, max, values }) => ({
-    id,
-    label,
-    color,
-    data: values.map((v) => norm(v, max)),
-    showMark: true,
-    valueFormatter: (
-      _normalizedValue: number | null,
-      context: { dataIndex: number }
-    ) => {
-      const abs = values[context.dataIndex];
-      return `${abs} / ${max}`;
-    },
-  }));
-
   return (
     <div
       className="w-full"
       aria-label="Evolução do desempenho em redação por mês"
     >
-      <h3 className="text-base font-semibold mb-2">
-        Evolução por mês (% do máximo)
-      </h3>
-      <ul className="flex flex-wrap gap-x-4 gap-y-1 mb-2 text-xs text-gray-700">
-        {seriesDefs.map(({ id, label, color }) => (
-          <li key={id} className="flex items-center gap-1.5">
-            <span
-              className="inline-block w-3 h-3 rounded-sm"
-              style={{ backgroundColor: color }}
-              aria-hidden
-            />
-            {label}
-          </li>
+      <h3 className="text-base font-semibold mb-2">Evolução por mês</h3>
+      <div className="mb-4">
+        <MiniLine
+          id={geral.id}
+          label={geral.label}
+          color={geral.color}
+          max={geral.max}
+          values={geral.values}
+          labels={labels}
+          months={monthKeys}
+          height={240}
+          onSelectMonth={onSelectMonth}
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {competencias.map((c) => (
+          <MiniLine
+            key={c.id}
+            id={c.id}
+            label={c.label}
+            color={c.color}
+            max={c.max}
+            values={c.values}
+            labels={labels}
+            months={monthKeys}
+            height={160}
+            onSelectMonth={onSelectMonth}
+          />
         ))}
-      </ul>
-      <LineChart
-        height={280}
-        xAxis={[{ data: labels, scaleType: "point" }]}
-        yAxis={[{ min: 0, max: 100 }]}
-        series={series}
-        margin={{ left: 40, right: 16, top: 16, bottom: 32 }}
-        slotProps={{ legend: { hidden: true } }}
-        onAreaClick={(_, params) => {
-          const idx = params?.dataIndex;
-          if (idx != null && ordered[idx]) onSelectMonth(ordered[idx].month);
-        }}
-        onMarkClick={(_, params) => {
-          const idx = params?.dataIndex;
-          if (idx != null && ordered[idx]) onSelectMonth(ordered[idx].month);
-        }}
-      />
+      </div>
       {selectedIndex >= 0 && (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 mt-3">
           Mês selecionado: {labels[selectedIndex]}
         </p>
       )}
-      <p className="text-xs text-gray-500 mt-1">
-        Valores normalizados em % do máximo (Geral 0–1000, C1–C5 0–200).
-        Tooltip mostra a nota absoluta.
-      </p>
     </div>
   );
 }

--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -25,6 +25,8 @@ interface MiniLineProps {
   months: string[];
   height: number;
   onSelectMonth: (month: string) => void;
+  tickInterval?: number[];
+  showGrid?: boolean;
 }
 
 function MiniLine({
@@ -37,6 +39,8 @@ function MiniLine({
   months,
   height,
   onSelectMonth,
+  tickInterval,
+  showGrid,
 }: MiniLineProps) {
   return (
     <div className="border rounded-md p-3 bg-white">
@@ -51,7 +55,11 @@ function MiniLine({
       <LineChart
         height={height}
         xAxis={[{ data: labels, scaleType: "point" }]}
-        yAxis={[{ min: 0, max }]}
+        yAxis={[
+          tickInterval
+            ? { min: 0, max, tickInterval }
+            : { min: 0, max },
+        ]}
         series={[
           {
             id,
@@ -67,6 +75,17 @@ function MiniLine({
         ]}
         margin={{ left: 36, right: 12, top: 8, bottom: 28 }}
         slotProps={{ legend: { hidden: true } }}
+        grid={showGrid ? { horizontal: true } : undefined}
+        sx={
+          showGrid
+            ? {
+                "& .MuiChartsGrid-line": {
+                  strokeDasharray: "3 3",
+                  stroke: "#d1d5db",
+                },
+              }
+            : undefined
+        }
         onAreaClick={(_, params) => {
           const idx = params?.dataIndex;
           if (idx != null && months[idx]) onSelectMonth(months[idx]);
@@ -170,6 +189,8 @@ export function EssayEvolutionChart({
             months={monthKeys}
             height={160}
             onSelectMonth={onSelectMonth}
+            tickInterval={[0, 40, 80, 120, 160, 200]}
+            showGrid
           />
         ))}
       </div>

--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -11,7 +11,7 @@ function formatMonth(yyyymm: string) {
   const [y, m] = yyyymm.split("-");
   const date = new Date(Number(y), Number(m) - 1, 1);
   return date
-    .toLocaleString("pt-BR", { month: "short", year: "2-digit" })
+    .toLocaleString("pt-BR", { month: "short" })
     .replace(".", "");
 }
 

--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -33,44 +33,51 @@ export function EssayEvolutionChart({
     {
       id: "geral",
       label: "Geral",
+      color: "#02B2AF",
       max: 1000,
       values: ordered.map((m) => m.geral),
     },
     {
       id: "c1",
       label: "C1 — Norma",
+      color: "#2E96FF",
       max: 200,
       values: ordered.map((m) => m.competencias.c1),
     },
     {
       id: "c2",
       label: "C2 — Tema",
+      color: "#B800D8",
       max: 200,
       values: ordered.map((m) => m.competencias.c2),
     },
     {
       id: "c3",
       label: "C3 — Argumentação",
+      color: "#60009B",
       max: 200,
       values: ordered.map((m) => m.competencias.c3),
     },
     {
       id: "c4",
       label: "C4 — Coesão",
+      color: "#2731C8",
       max: 200,
       values: ordered.map((m) => m.competencias.c4),
     },
     {
       id: "c5",
       label: "C5 — Proposta",
+      color: "#03008D",
       max: 200,
       values: ordered.map((m) => m.competencias.c5),
     },
   ];
 
-  const series = seriesDefs.map(({ id, label, max, values }) => ({
+  const series = seriesDefs.map(({ id, label, color, max, values }) => ({
     id,
     label,
+    color,
     data: values.map((v) => norm(v, max)),
     showMark: true,
     valueFormatter: (
@@ -90,12 +97,25 @@ export function EssayEvolutionChart({
       <h3 className="text-base font-semibold mb-2">
         Evolução por mês (% do máximo)
       </h3>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 mb-2 text-xs text-gray-700">
+        {seriesDefs.map(({ id, label, color }) => (
+          <li key={id} className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-3 h-3 rounded-sm"
+              style={{ backgroundColor: color }}
+              aria-hidden
+            />
+            {label}
+          </li>
+        ))}
+      </ul>
       <LineChart
         height={280}
         xAxis={[{ data: labels, scaleType: "point" }]}
         yAxis={[{ min: 0, max: 100 }]}
         series={series}
         margin={{ left: 40, right: 16, top: 16, bottom: 32 }}
+        slotProps={{ legend: { hidden: true } }}
         onAreaClick={(_, params) => {
           const idx = params?.dataIndex;
           if (idx != null && ordered[idx]) onSelectMonth(ordered[idx].month);

--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -197,6 +197,13 @@ export function EssayEvolutionChart({
       {selectedIndex >= 0 && (
         <p className="text-sm text-gray-500 mt-3">
           Mês selecionado: {labels[selectedIndex]}
+          {ordered[selectedIndex].studentsSubmittedTotal !== null && (
+            <span className="text-gray-400">
+              {" "}
+              · n={ordered[selectedIndex].studentsSubmittedTotal} aluno
+              {ordered[selectedIndex].studentsSubmittedTotal === 1 ? "" : "s"}
+            </span>
+          )}
         </p>
       )}
     </div>

--- a/src/components/organisms/classEssayAnalytics/KpiHeader.tsx
+++ b/src/components/organisms/classEssayAnalytics/KpiHeader.tsx
@@ -29,6 +29,8 @@ export function KpiHeader({ monthData, list, onRefresh, refreshing }: Props) {
   const notaColor = geral !== null ? getNotaColor(geral) : "text-gray-400";
 
   const studentsWithReview = monthData?.studentsWithAtLeastOneHumanReview ?? null;
+  const studentsSubmitted =
+    monthData?.studentsSubmittedTotal ?? null;
   const essaysReviewed = monthData?.essaysReviewedByHuman ?? 0;
   const essaysSubmitted = monthData?.essaysSubmittedTotal ?? 0;
   const humanReviewRate = monthData?.humanReviewRate ?? 0;
@@ -59,7 +61,7 @@ export function KpiHeader({ monthData, list, onRefresh, refreshing }: Props) {
         )}
       </div>
       <p className="text-sm text-gray-500">Período letivo: {start} – {end}</p>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         <Card>
           <CardContent className="pt-4">
             <p className="text-xs text-gray-500">Nota geral</p>
@@ -71,11 +73,24 @@ export function KpiHeader({ monthData, list, onRefresh, refreshing }: Props) {
         </Card>
         <Card>
           <CardContent className="pt-4">
+            <p className="text-xs text-gray-500">Participantes</p>
+            <p className="text-2xl font-bold">
+              {studentsSubmitted !== null ? studentsSubmitted : "—"}
+              <span className="text-sm font-normal text-gray-400">
+                /{list.totalStudents}
+              </span>
+            </p>
+            <p className="text-xs text-gray-400 mt-1">Entregaram redação</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
             <p className="text-xs text-gray-500">Alunos engajados</p>
             <p className="text-2xl font-bold">
               {studentsWithReview !== null ? studentsWithReview : "—"}
               <span className="text-sm font-normal text-gray-400">/{list.totalStudents}</span>
             </p>
+            <p className="text-xs text-gray-400 mt-1">Receberam revisão humana</p>
           </CardContent>
         </Card>
         <Card>

--- a/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/MonthPicker.tsx
@@ -1,6 +1,5 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
-import { formatPercent } from "@/utils/formatPercent";
 
 interface Props {
   months: ClassMonthsList["months"];
@@ -26,7 +25,7 @@ export function MonthPicker({ months, value, onChange }: Props) {
         <SelectContent>
           {months.map((m) => (
             <SelectItem key={m.month} value={m.month}>
-              {formatMonthLabel(m.month)} — {m.studentsWithAtLeastOneCompletedAttempt} alunos | {formatPercent(m.geral)}%
+              {formatMonthLabel(m.month)}
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/organisms/classSimuladoAnalytics/index.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/index.tsx
@@ -5,7 +5,6 @@ import { getClassSimuladoByMonth } from "@/services/prepCourse/class/getClassSim
 import { refreshClassSimuladoAnalytics } from "@/services/prepCourse/class/refreshClassSimuladoAnalytics";
 import { useRefreshPolling } from "@/hooks/useRefreshPolling";
 import { KpiHeader } from "./KpiHeader";
-import { MonthPicker } from "./MonthPicker";
 import { SampleSizeBanner } from "./SampleSizeBanner";
 import { EmptyState } from "./EmptyState";
 import { MateriaRadar } from "@/components/molecules/materiaRadar";
@@ -17,6 +16,7 @@ interface Props {
   token: string;
   selectedMonth?: string | null;
   onSelectMonth?: (month: string) => void;
+  onListLoaded?: (list: ClassMonthsList) => void;
 }
 
 export function ClassSimuladoAnalytics({
@@ -24,6 +24,7 @@ export function ClassSimuladoAnalytics({
   token,
   selectedMonth: selectedMonthProp,
   onSelectMonth,
+  onListLoaded,
 }: Props) {
   const isControlled = selectedMonthProp !== undefined && onSelectMonth !== undefined;
   const [list, setList] = useState<ClassMonthsList | null>(null);
@@ -49,6 +50,7 @@ export function ClassSimuladoAnalytics({
     listClassSimuladoMonths(classId, token)
       .then((data) => {
         setList(data);
+        onListLoaded?.(data);
         if (data.months.length > 0 && !selectedMonth) {
           setSelectedMonth(data.months[data.months.length - 1].month);
         }
@@ -144,15 +146,6 @@ export function ClassSimuladoAnalytics({
             months={list.months}
             selectedMonth={selectedMonth}
             onSelectMonth={(m) => {
-              setSelectedMonth(m);
-              setSelectedMateriaId(undefined);
-            }}
-          />
-
-          <MonthPicker
-            months={list.months}
-            value={selectedMonth}
-            onChange={(m) => {
               setSelectedMonth(m);
               setSelectedMateriaId(undefined);
             }}

--- a/src/components/templates/dashTemplate/index.tsx
+++ b/src/components/templates/dashTemplate/index.tsx
@@ -24,7 +24,9 @@ function DashTemplateContent({ hasMenu }: { hasMenu?: boolean }) {
     <div
       className={`relative top-[76px] h-[calc(100vh-76px)] w-full flex flex-row`}
     >
-      <div className={`xl:mr-0 w-full overflow-y-scroll scrollbar-hide flex-1`}>
+      <div
+        className={`xl:mr-0 w-full overflow-y-scroll scrollbar-hide flex-1 min-w-0`}
+      >
         <Outlet />
       </div>
       <div

--- a/src/pages/partnerClassWithStudents/index.tsx
+++ b/src/pages/partnerClassWithStudents/index.tsx
@@ -24,15 +24,22 @@ import { AttendanceHistoryModal } from "./modals/attendanceHistoryModal";
 import { AttendanceRecordByStudentModal } from "./modals/attendanceRecordByStudentModal";
 import { ClassSimuladoAnalytics } from "@/components/organisms/classSimuladoAnalytics";
 import { ClassEssayAnalytics } from "@/components/organisms/classEssayAnalytics";
+import { MonthPicker } from "@/components/organisms/classSimuladoAnalytics/MonthPicker";
+import { ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
 
 function ClassPerformanceTab({
   classId,
   token,
+  selectedMonth,
+  setSelectedMonth,
+  onListLoaded,
 }: {
   classId: string;
   token: string;
+  selectedMonth: string | null;
+  setSelectedMonth: (m: string) => void;
+  onListLoaded: (list: ClassMonthsList) => void;
 }) {
-  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
   return (
     <>
       <ClassSimuladoAnalytics
@@ -40,6 +47,7 @@ function ClassPerformanceTab({
         token={token}
         selectedMonth={selectedMonth}
         onSelectMonth={setSelectedMonth}
+        onListLoaded={onListLoaded}
       />
       <ClassEssayAnalytics
         classId={classId}
@@ -59,6 +67,11 @@ export function PartnerClassWithStudents() {
   const [students, setStudents] = useState<ClassStudent[]>([]);
   const [studentSelected, setStudentSelected] = useState<ClassStudent>(
     {} as ClassStudent
+  );
+  const [activeTab, setActiveTab] = useState<string>("alunos");
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
+  const [simuladoList, setSimuladoList] = useState<ClassMonthsList | null>(
+    null
   );
 
   const modals = useModals([
@@ -275,12 +288,25 @@ export function PartnerClassWithStudents() {
         )}
       </div>
 
-      <Tabs defaultValue="alunos" className="w-full mt-4">
-        <div className="px-4">
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="w-full mt-4"
+      >
+        <div className="px-4 flex items-center justify-between gap-4 flex-wrap">
           <TabsList>
             <TabsTrigger value="alunos">Alunos</TabsTrigger>
             <TabsTrigger value="desempenho">Desempenho</TabsTrigger>
           </TabsList>
+          {activeTab === "desempenho" &&
+            simuladoList &&
+            simuladoList.months.length > 0 && (
+              <MonthPicker
+                months={simuladoList.months}
+                value={selectedMonth}
+                onChange={setSelectedMonth}
+              />
+            )}
         </div>
 
         <TabsContent value="alunos">
@@ -326,7 +352,13 @@ export function PartnerClassWithStudents() {
         <TabsContent value="desempenho">
           <div className="p-4">
             {hashClassId && (
-              <ClassPerformanceTab classId={hashClassId} token={token} />
+              <ClassPerformanceTab
+                classId={hashClassId}
+                token={token}
+                selectedMonth={selectedMonth}
+                setSelectedMonth={setSelectedMonth}
+                onListLoaded={setSimuladoList}
+              />
             )}
           </div>
         </TabsContent>

--- a/src/types/classAnalytics/classEssayAnalytics.ts
+++ b/src/types/classAnalytics/classEssayAnalytics.ts
@@ -7,6 +7,12 @@ export interface ClassEssayMonthSummary {
   studentsWithAtLeastOneHumanReview: number;
   essaysReviewedByHuman: number;
   essaysSubmittedTotal: number;
+  /**
+   * Alunos distintos que submeteram pelo menos uma redação no mês.
+   * Pode ser null em snapshots gerados antes da introdução do campo —
+   * nesse caso a UI mostra "—" até o próximo refresh.
+   */
+  studentsSubmittedTotal: number | null;
   humanReviewRate: number;
   generatedAt: string;
 }


### PR DESCRIPTION
## Summary

Conjunto de ajustes solicitados após o merge da Fase C:

**Gráfico de evolução de redação**
- Legenda movida para fora do retângulo do gráfico
- Refatorado em **small multiples**: gráfico grande "Geral" no topo + grid responsivo (1/2/3 colunas) com 5 mini-charts (uma por competência)
- Mini-charts mostram grid pontilhado com tick em cada nota possível do ENEM (0/40/80/120/160/200)
- Eixo X usa apenas o mês abreviado ("jan", "fev") sem o ano
- Footer mostra `· n=X aluno(s)` para o mês selecionado (novo campo `studentsSubmittedTotal` vindo da API)

**Gráfico de evolução de simulado**
- Mesmo ajuste do eixo X (sem ano)

**Dashboard da turma (PartnerClassWithStudents)**
- Estado `activeTab`/`selectedMonth`/`simuladoList` movido para o componente pai
- `<MonthPicker>` agora aparece **na mesma linha** das abas (Alunos/Desempenho), do lado direito, e só na aba "Desempenho"
- Opções do select simplificadas: apenas o nome do mês

**KpiHeader de redação**
- Grid alterado para `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5`
- Nova métrica "Participantes" (`studentsSubmittedTotal / totalStudents`) com subtítulo "Entregaram redação"
- Adicionado subtítulo "Receberam revisão humana" em "Alunos engajados"

**DashTemplate (bug fix)**
- Adicionado `min-w-0` ao flex item de conteúdo. Sem isso, ao reabrir o sidebar após fechá-lo, os SVGs do MUI X-Charts mantinham a largura maior e o flex item não conseguia encolher (default `min-width: auto`), gerando scroll horizontal.

## Test Plan

- [x] `npm run build` → 0 erros
- [x] `npx tsc --noEmit` → 0 erros
- [ ] Validar visualmente os small multiples no Chrome/Safari
- [ ] Validar comportamento do MonthPicker alternando entre abas Alunos/Desempenho
- [ ] Fechar e reabrir sidebar na seção Desempenho — não deve aparecer scroll horizontal
- [ ] Verificar fallback "—" no card Participantes para snapshots antigos sem o campo

## Depende

Requer o merge do PR da API que expõe `studentsSubmittedTotal` no snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)