### PR TITLE
feat(class-analytics): feedback claro no refresh manual

### DIFF
--- a/src/components/organisms/classEssayAnalytics/KpiHeader.tsx
+++ b/src/components/organisms/classEssayAnalytics/KpiHeader.tsx
@@ -12,6 +12,19 @@ interface Props {
   list: ClassEssayMonthsList;
   onRefresh: () => void;
   refreshing: boolean;
+  requesting: boolean;
+}
+
+function formatGeneratedAt(generatedAt: string | null | undefined): string | null {
+  if (!generatedAt) return null;
+  const date = new Date(generatedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function getNotaColor(geral: number): string {
@@ -20,10 +33,17 @@ function getNotaColor(geral: number): string {
   return "text-green-600";
 }
 
-export function KpiHeader({ monthData, list, onRefresh, refreshing }: Props) {
+export function KpiHeader({
+  monthData,
+  list,
+  onRefresh,
+  refreshing,
+  requesting,
+}: Props) {
   const isActive = list.coursePeriod.isActive;
   const start = new Date(list.coursePeriod.startDate).toLocaleDateString("pt-BR");
   const end = new Date(list.coursePeriod.endDate).toLocaleDateString("pt-BR");
+  const lastUpdatedAt = formatGeneratedAt(monthData?.generatedAt);
 
   const geral = monthData ? Math.round(monthData.geral) : null;
   const notaColor = geral !== null ? getNotaColor(geral) : "text-gray-400";
@@ -45,19 +65,28 @@ export function KpiHeader({ monthData, list, onRefresh, refreshing }: Props) {
           {!isActive && <Badge variant="secondary">Turma arquivada</Badge>}
         </div>
         {isActive && (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={onRefresh}
-            disabled={refreshing}
-          >
-            {refreshing ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" />
+          <div className="flex flex-col items-end gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onRefresh}
+              disabled={requesting}
+            >
+              {requesting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              {requesting ? "Enfileirando..." : "Atualizar redação"}
+            </Button>
+            {(refreshing || lastUpdatedAt) && (
+              <p className="text-xs text-gray-400">
+                {refreshing
+                  ? "Processando em segundo plano..."
+                  : `Atualizado em ${lastUpdatedAt}`}
+              </p>
             )}
-            {refreshing ? "Atualizando..." : "Atualizar redação"}
-          </Button>
+          </div>
         )}
       </div>
       <p className="text-sm text-gray-500">Período letivo: {start} – {end}</p>

--- a/src/components/organisms/classEssayAnalytics/index.tsx
+++ b/src/components/organisms/classEssayAnalytics/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { AlertTriangle } from "lucide-react";
+import { toast } from "react-toastify";
 import type {
   ClassEssayMonthAnalytics,
   ClassEssayMonthsList,
@@ -31,6 +32,7 @@ export function ClassEssayAnalytics({
   const [monthData, setMonthData] = useState<ClassEssayMonthAnalytics | null>(null);
   const [monthLoading, setMonthLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [requesting, setRequesting] = useState(false);
   const [baselineGeneratedAt, setBaselineGeneratedAt] = useState<string | null>(null);
 
   // 1) Load months list once
@@ -76,36 +78,55 @@ export function ClassEssayAnalytics({
     if (latest) {
       setMonthData(latest);
       setRefreshing(false);
+      toast.success("Dados de redação atualizados!");
       // Refresh the list too so the new month appears
       listClassEssayMonths(classId, token).then(setList).catch(console.error);
     }
   }, [latest, classId, token]);
 
   useEffect(() => {
-    if (timedOut) setRefreshing(false);
+    if (timedOut) {
+      setRefreshing(false);
+      toast.info(
+        "Ainda processando em segundo plano. Recarregue a página em alguns minutos para ver os dados atualizados.",
+      );
+    }
   }, [timedOut]);
 
   const handleRefresh = useCallback(async () => {
-    if (refreshing) return;
-    setBaselineGeneratedAt(monthData?.generatedAt ?? null);
-    setRefreshing(true);
+    if (requesting || refreshing) return;
+    setRequesting(true);
     try {
       await refreshClassEssayAnalytics(classId, "current", token);
+      setBaselineGeneratedAt(monthData?.generatedAt ?? null);
+      setRefreshing(true);
+      toast.info(
+        "Atualização enfileirada. O processamento acontece em segundo plano — pode levar alguns minutos.",
+      );
     } catch (e) {
       console.error(e);
-      setRefreshing(false);
+      toast.error("Falha ao solicitar atualização. Tente novamente.");
+    } finally {
+      setRequesting(false);
     }
-  }, [classId, monthData, refreshing, token]);
+  }, [classId, monthData, refreshing, requesting, token]);
 
   const handleGenerate = useCallback(async () => {
-    setRefreshing(true);
+    if (requesting || refreshing) return;
+    setRequesting(true);
     try {
       await refreshClassEssayAnalytics(classId, "all", token);
+      setRefreshing(true);
+      toast.info(
+        "Geração enfileirada. O processamento acontece em segundo plano — pode levar alguns minutos.",
+      );
     } catch (e) {
       console.error(e);
-      setRefreshing(false);
+      toast.error("Falha ao solicitar geração. Tente novamente.");
+    } finally {
+      setRequesting(false);
     }
-  }, [classId, token]);
+  }, [classId, refreshing, requesting, token]);
 
   if (loading) {
     return (
@@ -132,7 +153,7 @@ export function ClassEssayAnalytics({
         <EmptyState
           variant="no-months"
           onGenerate={list.coursePeriod.isActive ? handleGenerate : undefined}
-          loading={refreshing}
+          loading={refreshing || requesting}
         />
       </section>
     );
@@ -155,6 +176,7 @@ export function ClassEssayAnalytics({
           list={list}
           onRefresh={handleRefresh}
           refreshing={refreshing}
+          requesting={requesting}
         />
 
         {showSampleBanner && (

--- a/src/components/organisms/classSimuladoAnalytics/KpiHeader.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/KpiHeader.tsx
@@ -10,12 +10,32 @@ interface Props {
   monthData: ClassMonthAnalytics | null;
   onRefresh: () => void;
   refreshing: boolean;
+  requesting: boolean;
 }
 
-export function KpiHeader({ list, monthData, onRefresh, refreshing }: Props) {
+function formatGeneratedAt(generatedAt: string | null | undefined): string | null {
+  if (!generatedAt) return null;
+  const date = new Date(generatedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function KpiHeader({
+  list,
+  monthData,
+  onRefresh,
+  refreshing,
+  requesting,
+}: Props) {
   const isActive = list.coursePeriod.isActive;
   const start = new Date(list.coursePeriod.startDate).toLocaleDateString("pt-BR");
   const end = new Date(list.coursePeriod.endDate).toLocaleDateString("pt-BR");
+  const lastUpdatedAt = formatGeneratedAt(monthData?.generatedAt);
 
   return (
     <div className="space-y-3">
@@ -25,19 +45,28 @@ export function KpiHeader({ list, monthData, onRefresh, refreshing }: Props) {
           {!isActive && <Badge variant="secondary">Turma arquivada</Badge>}
         </div>
         {isActive && (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={onRefresh}
-            disabled={refreshing}
-          >
-            {refreshing ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" />
+          <div className="flex flex-col items-end gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onRefresh}
+              disabled={requesting}
+            >
+              {requesting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              {requesting ? "Enfileirando..." : "Atualizar agora"}
+            </Button>
+            {(refreshing || lastUpdatedAt) && (
+              <p className="text-xs text-gray-400">
+                {refreshing
+                  ? "Processando em segundo plano..."
+                  : `Atualizado em ${lastUpdatedAt}`}
+              </p>
             )}
-            {refreshing ? "Atualizando..." : "Atualizar agora"}
-          </Button>
+          </div>
         )}
       </div>
       <p className="text-sm text-gray-500">Período letivo: {start} – {end}</p>

--- a/src/components/organisms/classSimuladoAnalytics/index.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import { ClassMonthAnalytics, ClassMonthsList } from "@/types/classAnalytics/classSimuladoAnalytics";
 import { listClassSimuladoMonths } from "@/services/prepCourse/class/listClassSimuladoMonths";
 import { getClassSimuladoByMonth } from "@/services/prepCourse/class/getClassSimuladoByMonth";
@@ -41,6 +42,7 @@ export function ClassSimuladoAnalytics({
   const [monthData, setMonthData] = useState<ClassMonthAnalytics | null>(null);
   const [monthLoading, setMonthLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [requesting, setRequesting] = useState(false);
   const [selectedMateriaId, setSelectedMateriaId] = useState<string | undefined>(undefined);
   const [view, setView] = useState<"materia" | "frente">("materia");
   const [viewTouched, setViewTouched] = useState(false);
@@ -89,31 +91,52 @@ export function ClassSimuladoAnalytics({
     if (latest) {
       setMonthData(latest);
       setRefreshing(false);
+      toast.success("Dados de simulado atualizados!");
     }
   }, [latest]);
 
   useEffect(() => {
-    if (timedOut) setRefreshing(false);
+    if (timedOut) {
+      setRefreshing(false);
+      toast.info(
+        "Ainda processando em segundo plano. Recarregue a página em alguns minutos para ver os dados atualizados.",
+      );
+    }
   }, [timedOut]);
 
   const handleRefresh = useCallback(async () => {
-    if (!selectedMonth || refreshing) return;
-    setRefreshing(true);
+    if (!selectedMonth || requesting || refreshing) return;
+    setRequesting(true);
     try {
       await refreshClassSimuladoAnalytics(classId, "current", token);
-    } catch {
-      setRefreshing(false);
+      setRefreshing(true);
+      toast.info(
+        "Atualização enfileirada. O processamento acontece em segundo plano — pode levar alguns minutos.",
+      );
+    } catch (e) {
+      console.error(e);
+      toast.error("Falha ao solicitar atualização. Tente novamente.");
+    } finally {
+      setRequesting(false);
     }
-  }, [classId, selectedMonth, refreshing, token]);
+  }, [classId, selectedMonth, refreshing, requesting, token]);
 
   const handleGenerate = useCallback(async () => {
-    setRefreshing(true);
+    if (requesting || refreshing) return;
+    setRequesting(true);
     try {
       await refreshClassSimuladoAnalytics(classId, "all", token);
-    } catch {
-      setRefreshing(false);
+      setRefreshing(true);
+      toast.info(
+        "Geração enfileirada. O processamento acontece em segundo plano — pode levar alguns minutos.",
+      );
+    } catch (e) {
+      console.error(e);
+      toast.error("Falha ao solicitar geração. Tente novamente.");
+    } finally {
+      setRequesting(false);
     }
-  }, [classId, token]);
+  }, [classId, refreshing, requesting, token]);
 
   if (loading) {
     return <p className="py-8 text-center text-sm text-gray-400">Carregando dados da turma...</p>;
@@ -132,13 +155,14 @@ export function ClassSimuladoAnalytics({
         monthData={monthData}
         onRefresh={handleRefresh}
         refreshing={refreshing}
+        requesting={requesting}
       />
 
       {list.months.length === 0 ? (
         <EmptyState
           variant="no-months"
           onGenerate={list.coursePeriod.isActive ? handleGenerate : undefined}
-          loading={refreshing}
+          loading={refreshing || requesting}
         />
       ) : (
         <>

--- a/src/pages/partnerClassWithStudents/index.tsx
+++ b/src/pages/partnerClassWithStudents/index.tsx
@@ -74,6 +74,15 @@ export function PartnerClassWithStudents() {
     null
   );
 
+  const handleSimuladoListLoaded = (list: ClassMonthsList) => {
+    setSimuladoList(list);
+    if (list.months.length > 0) {
+      setSelectedMonth((current) =>
+        current ?? list.months[list.months.length - 1].month
+      );
+    }
+  };
+
   const modals = useModals([
     "modalAttendanceHistory",
     "modalAttendanceRecordByStudent",
@@ -357,7 +366,7 @@ export function PartnerClassWithStudents() {
                 token={token}
                 selectedMonth={selectedMonth}
                 setSelectedMonth={setSelectedMonth}
-                onListLoaded={setSimuladoList}
+                onListLoaded={handleSimuladoListLoaded}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

Quando o usuário clicava em "Atualizar" no dashboard de redação/simulado, o botão ficava em loading e nada mais era informado — dava a impressão de que a tela se atualizaria sozinha imediatamente. Esta PR melhora o feedback visual:

- **Estado `requesting` separado de `refreshing`**: botão libera assim que o backend enfileira (chamada HTTP curta), mantém `refreshing` apenas durante o polling de fundo
- **Toasts em cada transição**:
  - Ao enfileirar: `"Atualização enfileirada. O processamento acontece em segundo plano — pode levar alguns minutos."`
  - Polling detecta dados novos: `"Dados atualizados!"`
  - Polling expira (90s): `"Ainda processando em segundo plano. Recarregue a página em alguns minutos."`
  - Falha HTTP: `"Falha ao solicitar atualização. Tente novamente."`
- **Timestamp da última atualização** no KpiHeader: `"Atualizado em DD/MM HH:mm"` baseado em `monthData.generatedAt`, ou `"Processando em segundo plano..."` enquanto o polling roda

Aplicado simetricamente nos dois organismos: `classSimuladoAnalytics` e `classEssayAnalytics`.

## Test plan

- [ ] Abrir aba "Desempenho" de uma turma com snapshots existentes → ver `"Atualizado em DD/MM HH:mm"` ao lado do botão
- [ ] Clicar em "Atualizar agora" / "Atualizar redação" → toast aparece, botão libera rápido, status muda para `"Processando em segundo plano..."`
- [ ] Aguardar polling completar → toast de sucesso aparece, timestamp atualiza
- [ ] Forçar timeout (esperar 90s sem o worker rodar) → toast de info aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)