### PR TITLE
fix(class-analytics): polimento do dashboard — gráficos e mês inicial

### DIFF
--- a/src/components/molecules/essayEvolutionChart/index.tsx
+++ b/src/components/molecules/essayEvolutionChart/index.tsx
@@ -111,20 +111,21 @@ export function EssayEvolutionChart({
   const monthKeys = ordered.map((m) => m.month);
   const selectedIndex = ordered.findIndex((m) => m.month === selectedMonth);
 
-  const geral = {
-    id: "geral",
-    label: "Geral",
-    color: "#02B2AF",
-    max: 1000,
-    values: ordered.map((m) => m.geral),
-  };
-
-  const competencias = [
+  const charts = [
+    {
+      id: "geral",
+      label: "Geral",
+      color: "#02B2AF",
+      max: 1000,
+      tickInterval: [0, 200, 400, 600, 800, 1000],
+      values: ordered.map((m) => m.geral),
+    },
     {
       id: "c1",
       label: "C1 — Norma",
       color: "#2E96FF",
       max: 200,
+      tickInterval: [0, 40, 80, 120, 160, 200],
       values: ordered.map((m) => m.competencias.c1),
     },
     {
@@ -132,6 +133,7 @@ export function EssayEvolutionChart({
       label: "C2 — Tema",
       color: "#B800D8",
       max: 200,
+      tickInterval: [0, 40, 80, 120, 160, 200],
       values: ordered.map((m) => m.competencias.c2),
     },
     {
@@ -139,6 +141,7 @@ export function EssayEvolutionChart({
       label: "C3 — Argumentação",
       color: "#60009B",
       max: 200,
+      tickInterval: [0, 40, 80, 120, 160, 200],
       values: ordered.map((m) => m.competencias.c3),
     },
     {
@@ -146,6 +149,7 @@ export function EssayEvolutionChart({
       label: "C4 — Coesão",
       color: "#2731C8",
       max: 200,
+      tickInterval: [0, 40, 80, 120, 160, 200],
       values: ordered.map((m) => m.competencias.c4),
     },
     {
@@ -153,6 +157,7 @@ export function EssayEvolutionChart({
       label: "C5 — Proposta",
       color: "#03008D",
       max: 200,
+      tickInterval: [0, 40, 80, 120, 160, 200],
       values: ordered.map((m) => m.competencias.c5),
     },
   ];
@@ -163,21 +168,8 @@ export function EssayEvolutionChart({
       aria-label="Evolução do desempenho em redação por mês"
     >
       <h3 className="text-base font-semibold mb-2">Evolução por mês</h3>
-      <div className="mb-4">
-        <MiniLine
-          id={geral.id}
-          label={geral.label}
-          color={geral.color}
-          max={geral.max}
-          values={geral.values}
-          labels={labels}
-          months={monthKeys}
-          height={240}
-          onSelectMonth={onSelectMonth}
-        />
-      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {competencias.map((c) => (
+        {charts.map((c) => (
           <MiniLine
             key={c.id}
             id={c.id}
@@ -189,7 +181,7 @@ export function EssayEvolutionChart({
             months={monthKeys}
             height={160}
             onSelectMonth={onSelectMonth}
-            tickInterval={[0, 40, 80, 120, 160, 200]}
+            tickInterval={c.tickInterval}
             showGrid
           />
         ))}

--- a/src/components/organisms/classEssayAnalytics/index.tsx
+++ b/src/components/organisms/classEssayAnalytics/index.tsx
@@ -43,7 +43,8 @@ export function ClassEssayAnalytics({
         setList(data);
         // 3) Auto-select latest month when list loads & no selection yet
         if (data.months.length > 0 && !selectedMonth) {
-          onSelectMonth(data.months[data.months.length - 1].month);
+          const sorted = [...data.months].sort((a, b) => a.month.localeCompare(b.month));
+          onSelectMonth(sorted[sorted.length - 1].month);
         }
       })
       .catch(console.error)

--- a/src/components/organisms/classSimuladoAnalytics/index.tsx
+++ b/src/components/organisms/classSimuladoAnalytics/index.tsx
@@ -54,7 +54,8 @@ export function ClassSimuladoAnalytics({
         setList(data);
         onListLoaded?.(data);
         if (data.months.length > 0 && !selectedMonth) {
-          setSelectedMonth(data.months[data.months.length - 1].month);
+          const sorted = [...data.months].sort((a, b) => a.month.localeCompare(b.month));
+          setSelectedMonth(sorted[sorted.length - 1].month);
         }
       })
       .finally(() => setLoading(false));

--- a/src/pages/partnerClassWithStudents/index.tsx
+++ b/src/pages/partnerClassWithStudents/index.tsx
@@ -77,9 +77,8 @@ export function PartnerClassWithStudents() {
   const handleSimuladoListLoaded = (list: ClassMonthsList) => {
     setSimuladoList(list);
     if (list.months.length > 0) {
-      setSelectedMonth((current) =>
-        current ?? list.months[list.months.length - 1].month
-      );
+      const sorted = [...list.months].sort((a, b) => a.month.localeCompare(b.month));
+      setSelectedMonth((current) => current ?? sorted[sorted.length - 1].month);
     }
   };
 


### PR DESCRIPTION
## Summary

- Gráficos de evolução da redação: "Geral" agora tem o mesmo tamanho dos 5 de competência — 6 cards iguais em grid 3×2
- Mês mais recente pré-selecionado ao abrir a aba Desempenho (corrige dependência da ordem de chegada da API)

## Test plan

- [ ] Abrir aba Desempenho → MonthPicker já mostra o mês mais recente selecionado
- [ ] Verificar seção "Evolução por mês" da redação → 6 gráficos iguais em grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)