### PR TITLE
refactor: pequenas refatorações no painel do estudante

### DIFF
--- a/src/components/templates/dashTemplate/index.tsx
+++ b/src/components/templates/dashTemplate/index.tsx
@@ -4,13 +4,17 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { useEffect, useMemo, useState } from "react";
-import { Outlet } from "react-router-dom";
+import { useMemo } from "react";
+import { Outlet, useLocation } from "react-router-dom";
 import { BaseTemplateContext } from "../../../context/baseTemplateContext";
 import { headerDash } from "../../../pages/dash/data";
-import { NEWS } from "../../../routes/path";
-import { getNews } from "../../../services/news/getNews";
+import { DASH } from "../../../routes/path";
+import { ItemMenuProps } from "../../../components/molecules/menuItems";
 import BaseTemplate from "../baseTemplate";
+
+const painelDoEstudanteLink: ItemMenuProps = {
+  Home_Menu_Item_id: { id: 1, name: "Painel do Estudante", link: DASH, target: "_self" },
+};
 
 type DashTemplateProps = {
   className?: string;
@@ -44,27 +48,19 @@ function DashTemplateContent({ hasMenu }: { hasMenu?: boolean }) {
 }
 
 function DashTemplate({ className, hasMenu }: DashTemplateProps) {
-  const [hasNews, setHasNews] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    getNews()
-      .then((res) => setHasNews((res.data?.length ?? 0) > 0))
-      .catch(() => setHasNews(false));
-  }, []);
+  const { pathname } = useLocation();
+  const isMainDash = pathname === DASH || pathname === `${DASH}/`;
 
   const headerValue = useMemo(() => {
-    const pageLinks =
-      hasNews === false
-        ? headerDash.pageLinks.filter(
-            (l) => l.Home_Menu_Item_id.link !== NEWS,
-          )
-        : headerDash.pageLinks;
-    return { ...headerDash, pageLinks };
-  }, [hasNews]);
+    return {
+      ...headerDash,
+      pageLinks: isMainDash ? [] : [painelDoEstudanteLink],
+    };
+  }, [isMainDash]);
 
   return (
     <BaseTemplateContext.Provider
-      value={{ header: headerValue, hasFooter: false, hasNews }}
+      value={{ header: headerValue, hasFooter: false }}
     >
       <BaseTemplate
         className={`overflow-y-clip scrollbar-hide h-full ${className} overflow-x-hidden`}

--- a/src/pages/dash/data.ts
+++ b/src/pages/dash/data.ts
@@ -85,14 +85,6 @@ export const headerDash: HeaderData = {
         target: "_self",
       },
     },
-    {
-      Home_Menu_Item_id: {
-        id: 2,
-        name: "Simulados",
-        link: `${DASH}/${SIMULADO}`,
-        target: "_self",
-      },
-    },
   ],
 };
 
@@ -268,9 +260,9 @@ export const adminMenuItems: DashCardMenu[] = [
 export const studentMenuItem: DashCardMenu = {
   id: 7,
   bg: "bg-red",
-  title: "Cursinho",
+  title: "Meus Estudos",
   image: IoSchool,
-  alt: "Cursinho",
+  alt: "Meus Estudos",
   subMenuList: [
     {
       icon: FaClipboardList,
@@ -285,6 +277,12 @@ export const studentMenuItem: DashCardMenu = {
       text: "Redações",
       link: `/dashboard/${ESSAY_WRITE}`,
       permissions: [Roles.visualizarMinhasInscricoes],
+    },
+    {
+      icon: GoGraph,
+      alt: "simulados",
+      text: "Simulados",
+      link: `${DASH}/${SIMULADO}`,
     },
   ],
 };

--- a/src/routes/baseRoutes.tsx
+++ b/src/routes/baseRoutes.tsx
@@ -1,33 +1,20 @@
 import { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { BaseTemplateContext } from "../context/baseTemplateContext";
-import { headerDash } from "../pages/dash/data";
 import { footer, header } from "../pages/homeLegacy/data";
-import { HOME_PATH, NEWS } from "../routes/path";
+import { DASH, HOME_PATH, NEWS } from "../routes/path";
 import { getNews } from "../services/news/getNews";
 import { useAuthStore } from "../store/auth";
 import { ItemMenuProps } from "../components/molecules/menuItems";
 
-function mergeHeaderLinksForHome(
-  homeLinks: ItemMenuProps[],
-  dashLinks: ItemMenuProps[],
-): ItemMenuProps[] {
-  const seen = new Set<string>();
-  const merged: ItemMenuProps[] = [];
-  let nextId = 1;
-
-  for (const item of [...homeLinks, ...dashLinks]) {
-    const link = item.Home_Menu_Item_id.link;
-    if (seen.has(link)) continue;
-    seen.add(link);
-    merged.push({
-      ...item,
-      Home_Menu_Item_id: { ...item.Home_Menu_Item_id, id: nextId++ },
-    });
-  }
-  merged.pop();
-  return merged;
-}
+const painelDoEstudanteLink: ItemMenuProps = {
+  Home_Menu_Item_id: {
+    id: 99,
+    name: "Painel do Estudante",
+    link: DASH,
+    target: "_self",
+  },
+};
 
 export function BaseRoutes() {
   const [hasNews, setHasNews] = useState<boolean | null>(null);
@@ -42,12 +29,10 @@ export function BaseRoutes() {
   }, []);
 
   let basePageLinks: ItemMenuProps[];
-  if (!token) {
-    basePageLinks = header.pageLinks;
-  } else if (isHome) {
-    basePageLinks = mergeHeaderLinksForHome(header.pageLinks, headerDash.pageLinks);
+  if (token && isHome) {
+    basePageLinks = [...header.pageLinks, painelDoEstudanteLink];
   } else {
-    basePageLinks = headerDash.pageLinks;
+    basePageLinks = header.pageLinks;
   }
 
   const pageLinks =


### PR DESCRIPTION
## Summary

- Renomeia o menu **Cursinho** do estudante para **Meus Estudos**
- Move **Simulados** do header para dentro de **Meus Estudos** (junto com Inscrições e Redações)
- Remove o item Simulados do `headerDash.pageLinks`
- **Header da dashboard** remodelado por rota:
  - Home (logado): exibe "Painel do Estudante" no menu
  - `/dashboard` (rota principal): header sem itens no menu
  - Demais rotas da dashboard: exibe "Painel do Estudante" centralizado no header
- Simplifica `BaseRoutes` (remove `mergeHeaderLinksForHome`)
- Simplifica `DashTemplate` (remove fetch de news desnecessário, header derivado da rota)

## Test plan

- [ ] Usuário não logado: header da home sem alterações
- [ ] Usuário logado na home (`/`): aparece "Painel do Estudante" no menu do header
- [ ] Usuário logado em `/dashboard`: header sem itens no menu
- [ ] Usuário logado em qualquer sub-rota da dashboard: aparece "Painel do Estudante" centralizado no header, clique leva de volta a `/dashboard`
- [ ] Menu lateral da dashboard: card do estudante exibe "Meus Estudos" com itens Inscrições, Redações e Simulados

🤖 Generated with [Claude Code](https://claude.com/claude-code)