### PR TITLE
refactor: sidebar colapsa para faixa fina com trigger interno

### DIFF
--- a/src/components/organisms/sidebarDash/index.tsx
+++ b/src/components/organisms/sidebarDash/index.tsx
@@ -8,6 +8,7 @@ import {
   SidebarGroupContent,
   SidebarHeader,
   SidebarMenu,
+  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Roles } from "@/enums/roles/roles";
 import { useFetch } from "@/hooks/useFetch";
@@ -50,11 +51,14 @@ export function SidebarDash() {
     setOpened(opened === cardId ? 0 : cardId);
   };
   return (
-    <Sidebar side="right">
-      <SidebarHeader>{isSupportAgent && <SupportInboxBadge />}</SidebarHeader>
+    <Sidebar side="right" collapsible="icon">
+      <SidebarHeader className="flex flex-row items-center justify-start pt-4 pb-2">
+        <SidebarTrigger />
+        {isSupportAgent && <SupportInboxBadge />}
+      </SidebarHeader>
       <SidebarContent>
-        <SidebarGroup className="pt-12 overflow-y-scroll scrollbar-hide">
-          <SidebarGroupContent>
+        <SidebarGroup className="overflow-y-scroll scrollbar-hide">
+          <SidebarGroupContent className="group-data-[collapsible=icon]:hidden">
             <SidebarMenu className="py-4 gap-0">
               {dashCardMenuItems.map((card) => (
                 <DashCard

--- a/src/components/templates/dashTemplate/index.tsx
+++ b/src/components/templates/dashTemplate/index.tsx
@@ -1,9 +1,5 @@
 import { SidebarDash } from "@/components/organisms/sidebarDash";
-import {
-  SidebarProvider,
-  SidebarTrigger,
-  useSidebar,
-} from "@/components/ui/sidebar";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { useMemo } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { BaseTemplateContext } from "../../../context/baseTemplateContext";
@@ -22,27 +18,17 @@ type DashTemplateProps = {
 };
 
 function DashTemplateContent({ hasMenu }: { hasMenu?: boolean }) {
-  const { open } = useSidebar();
-
   return (
-    <div
-      className={`relative top-[76px] h-[calc(100vh-76px)] w-full flex flex-row`}
-    >
-      <div
-        className={`xl:mr-0 w-full overflow-y-scroll scrollbar-hide flex-1 min-w-0`}
-      >
+    <div className="relative top-[76px] h-[calc(100vh-76px)] w-full flex flex-row">
+      <div className="xl:mr-0 w-full overflow-y-scroll scrollbar-hide flex-1 min-w-0">
         <Outlet />
       </div>
-      <div
-        className={`z-20 h-[calc(100vh-76px)] absolute xl:relative xl:right-0 transition-all duration-200`}
-      >
-        {hasMenu ? <SidebarDash /> : <></>}
+      <div className="z-20 h-[calc(100vh-76px)] absolute xl:relative xl:right-0">
+        {hasMenu && <SidebarDash />}
       </div>
-      <SidebarTrigger
-        className={`fixed z-30 top-24 transition-all duration-200 ${
-          open ? "right-[0.5rem] xl:right-[16rem]" : "right-4"
-        }`}
-      />
+      {hasMenu && (
+        <SidebarTrigger className="xl:hidden fixed z-30 top-24 right-4" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Troca `collapsible="offcanvas"` por `collapsible="icon"`: ao fechar, o sidebar colapsa para uma faixa fina de 3rem em vez de desaparecer completamente
- Move o `SidebarTrigger` para dentro do `SidebarHeader` (desktop xl+), eliminando o botão flutuante que sobrepunha o conteúdo da página
- Cards coloridos ficam ocultos na faixa colapsada via `group-data-[collapsible=icon]:hidden`
- Mantém um `SidebarTrigger` externo com `xl:hidden` para mobile, pois o trigger interno fica inacessível dentro do Sheet fechado

## Test plan

- [ ] Desktop (xl+): sidebar abre e fecha normalmente; quando fechado, faixa fina de ~3rem permanece visível na direita com o hamburguer no topo
- [ ] Desktop: botão hamburguer não sobrepõe conteúdo da página em nenhum estado
- [ ] Mobile (< xl): botão flutuante externo abre/fecha o Sheet do sidebar normalmente
- [ ] Cards coloridos somem na faixa colapsada; reaparecem ao expandir

🤖 Generated with [Claude Code](https://claude.com/claude-code)