### PR TITLE
refactor(home,quem-somos,dash-home): polimento de UI e flexibilização de upload de logo

### DIFF
--- a/src/components/atoms/photoEditor/index.tsx
+++ b/src/components/atoms/photoEditor/index.tsx
@@ -4,18 +4,36 @@ import { Check, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import Cropper, { Area } from "react-easy-crop";
 
+export interface AspectPreset {
+  /** Label exibido no chip (ex.: "1:1", "16:9", "Original") */
+  label: string;
+  /**
+   * Aspect ratio (largura/altura). Quando omitido, o editor usa a proporção
+   * natural da imagem carregada (sem recorte forçado).
+   */
+  aspect?: number;
+  /** Override do targetSize para este preset. Quando omitido, usa o targetSize do PhotoEditor (ou pixels do crop se ambos forem omitidos). */
+  targetSize?: { width: number; height: number };
+}
+
 interface PhotoEditorProps {
   isOpen: boolean;
   handleClose: () => void;
   /** File da foto; a URL é criada e revogada internamente para evitar imagem quebrada (ex.: Strict Mode). */
   photo: File;
   onConfirm: (file: File) => void;
-  /** Proporção do recorte (largura/altura). Default: 3/4. */
+  /** Proporção do recorte (largura/altura). Default: 3/4. Ignorado quando aspectPresets é usado. */
   aspect?: number;
   /** Dimensões finais da imagem cropada (canvas). Quando omitido, usa as pixels do crop. */
   targetSize?: { width: number; height: number };
   /** Formato de saída. PNG preserva transparência; JPEG é menor. Default: jpeg. */
   outputFormat?: "image/jpeg" | "image/png";
+  /**
+   * Lista de presets de aspect ratio. Quando fornecida, renderiza chips de
+   * seleção acima da área de crop e ignora os props `aspect` e `targetSize`
+   * (cada preset traz os seus próprios).
+   */
+  aspectPresets?: AspectPreset[];
 }
 
 const PhotoEditor = ({
@@ -26,11 +44,14 @@ const PhotoEditor = ({
   aspect = 3 / 4,
   targetSize,
   outputFormat = "image/jpeg",
+  aspectPresets,
 }: PhotoEditorProps) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const [naturalAspect, setNaturalAspect] = useState<number | null>(null);
+  const [activePresetIndex, setActivePresetIndex] = useState(0);
 
   // Criar e revogar a URL dentro do editor evita revogação precoce no parent (ex.: React Strict Mode)
   useEffect(() => {
@@ -43,16 +64,39 @@ const PhotoEditor = ({
     };
   }, [photo]);
 
+  // Reseta seleção quando a foto muda
+  useEffect(() => {
+    setActivePresetIndex(0);
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+  }, [photo]);
+
   const onCropComplete = useCallback((_: Area, croppedAreaPixels: Area) => {
     setCroppedAreaPixels(croppedAreaPixels);
   }, []);
+
+  const activePreset: AspectPreset | null =
+    aspectPresets && aspectPresets.length > 0
+      ? (aspectPresets[activePresetIndex] ?? aspectPresets[0])
+      : null;
+
+  // Aspect efetivo enviado ao Cropper. Quando o preset não define aspect, usa
+  // a proporção natural da imagem (= sem corte forçado, "livre").
+  const effectiveAspect: number = activePreset
+    ? (activePreset.aspect ?? naturalAspect ?? aspect)
+    : aspect;
+
+  // Target size efetivo: preset > prop > pixels do crop.
+  const effectiveTargetSize = activePreset
+    ? activePreset.targetSize
+    : targetSize;
 
   const handleConfirm = async () => {
     if (!croppedAreaPixels || !photoUrl) return;
     const croppedImage = await getCroppedImg(
       photoUrl,
       croppedAreaPixels,
-      targetSize,
+      effectiveTargetSize,
       outputFormat,
     );
     onConfirm(croppedImage);
@@ -65,9 +109,34 @@ const PhotoEditor = ({
       className="bg-black/80 rounded-lg sm:rounded-xl p-2 sm:p-4 max-h-[100dvh] flex flex-col overflow-hidden shadow-2xl w-[95vw] sm:w-[min(720px,92vw)] max-w-none"
       closer={false}
     >
+      {/* Chips de aspect ratio */}
+      {aspectPresets && aspectPresets.length > 0 && (
+        <div className="flex flex-wrap gap-2 p-2 sm:p-3 bg-gray-900 rounded-t-lg sm:rounded-t-xl">
+          {aspectPresets.map((p, i) => (
+            <button
+              key={`${p.label}-${i}`}
+              type="button"
+              onClick={() => setActivePresetIndex(i)}
+              className={[
+                "px-3 py-1.5 rounded-full text-xs sm:text-sm font-semibold transition-colors",
+                i === activePresetIndex
+                  ? "bg-white text-gray-900"
+                  : "bg-gray-700 text-gray-200 hover:bg-gray-600",
+              ].join(" ")}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
       {/* Área do crop: ocupa boa parte da tela no mobile e desktop */}
       <div
-        className="relative w-full flex-1 flex min-h-0 rounded-t-lg sm:rounded-t-xl overflow-hidden bg-gray-900"
+        className={[
+          "relative w-full flex-1 flex min-h-0 overflow-hidden bg-gray-900",
+          aspectPresets && aspectPresets.length > 0
+            ? ""
+            : "rounded-t-lg sm:rounded-t-xl",
+        ].join(" ")}
         style={{
           // Mobile: ~60vh; desktop: até ~75dvh, sempre pelo menos 320px para o Cropper renderizar
           minHeight: "clamp(320px, 60vh, 75dvh)",
@@ -79,10 +148,13 @@ const PhotoEditor = ({
             image={photoUrl}
             crop={crop}
             zoom={zoom}
-            aspect={aspect}
+            aspect={effectiveAspect}
             onCropChange={setCrop}
             onZoomChange={setZoom}
             onCropComplete={onCropComplete}
+            onMediaLoaded={(size) =>
+              setNaturalAspect(size.naturalWidth / size.naturalHeight)
+            }
           />
         )}
       </div>

--- a/src/pages/dashHome/modals/ModalEditSupporter.tsx
+++ b/src/pages/dashHome/modals/ModalEditSupporter.tsx
@@ -8,8 +8,17 @@ import { createHomeSupporter } from "../../../services/home/createHomeSupporter"
 import { updateHomeSupporter } from "../../../services/home/updateHomeSupporter";
 import { uploadHomeSupporterLogo } from "../../../services/home/uploadHomeSupporterLogo";
 import { homeContentFile } from "../../../services/urls";
-import PhotoEditor from "@/components/atoms/photoEditor";
-import { HOME_IMAGE_ASPECT, HOME_IMAGE_SIZE } from "../constants";
+import PhotoEditor, { AspectPreset } from "@/components/atoms/photoEditor";
+import { HOME_IMAGE_SIZE } from "../constants";
+
+const SUPPORTER_ASPECT_PRESETS: AspectPreset[] = [
+  { label: "1:1 (quadrado)", aspect: 1, targetSize: HOME_IMAGE_SIZE.supporter },
+  { label: "4:3", aspect: 4 / 3 },
+  { label: "16:9", aspect: 16 / 9 },
+  { label: "3:4", aspect: 3 / 4 },
+  { label: "9:16", aspect: 9 / 16 },
+  { label: "Original (livre)" },
+];
 
 interface Props {
   isOpen: boolean;
@@ -225,15 +234,14 @@ export default function ModalEditSupporter({
             }}
           />
           <span className="text-xs text-gray-500">
-            Proporção: 1:1 (quadrado). Salvo como PNG — fundo transparente é preservado.
+            Escolha a proporção desejada no editor (ou "Original" para manter a forma da imagem). Salvo como PNG — fundo transparente é preservado.
           </span>
         </div>
         {pendingCrop && (
           <PhotoEditor
             isOpen
             photo={pendingCrop}
-            aspect={HOME_IMAGE_ASPECT.supporter}
-            targetSize={HOME_IMAGE_SIZE.supporter}
+            aspectPresets={SUPPORTER_ASPECT_PRESETS}
             outputFormat="image/png"
             handleClose={() => setPendingCrop(null)}
             onConfirm={(cropped) => {

--- a/src/pages/homeV2/sections/AboutSection/AboutDescription.tsx
+++ b/src/pages/homeV2/sections/AboutSection/AboutDescription.tsx
@@ -1,112 +1,24 @@
 // client-vcnafacul/src/pages/homeV2/sections/AboutSection/AboutDescription.tsx
-import { useState } from "react";
 import { Link } from "react-router-dom";
-import * as Dialog from "@radix-ui/react-dialog";
 import RichTextRenderer from "../../../../components/atoms/richTextRenderer/RichTextRenderer";
 import { QUEM_SOMOS_PATH } from "../../../../routes/path";
 
-function SaibaMaisLink() {
-  return (
-    <Link
-      to={QUEM_SOMOS_PATH}
-      className="inline-flex items-center gap-2 mt-4 rounded-full px-6 py-2.5 text-sm font-semibold bg-[#37d6b5] text-[#0b2747] hover:bg-[#2bbfa1] hover:-translate-y-0.5 transition-all duration-200 shadow-md self-start"
-    >
-      Saiba mais →
-    </Link>
-  );
-}
-
-const SHORT_LIMIT = 200;
-const MEDIUM_LIMIT = 500;
-
 export function AboutDescription({ description }: { description: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const len = description.length;
-
-  if (len <= SHORT_LIMIT) {
-    return (
-      <div className="flex flex-col">
-        <div className="opacity-85 text-base md:text-lg leading-relaxed line-clamp-3">
-          <RichTextRenderer
-            content={description}
-            contentFormat="markdown"
-            className="prose-invert"
-          />
-        </div>
-        <SaibaMaisLink />
-      </div>
-    );
-  }
-
-  if (len <= MEDIUM_LIMIT) {
-    return (
-      <div className="flex flex-col">
-        <div
-          className={[
-            "opacity-85 text-base md:text-lg leading-relaxed transition-[max-height] duration-500",
-            expanded ? "max-h-[1000px]" : "max-h-32 overflow-hidden",
-          ].join(" ")}
-        >
-          <RichTextRenderer
-            content={description}
-            contentFormat="markdown"
-            className="prose-invert"
-          />
-        </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="mt-3 text-[#37d6b5] underline text-sm font-semibold"
-        >
-          {expanded ? "Ler menos" : "Ler mais"}
-        </button>
-        <SaibaMaisLink />
-      </div>
-    );
-  }
-
-  // Long: drawer
   return (
-    <Dialog.Root>
-      <div className="flex flex-col">
-        <div className="opacity-85 text-base md:text-lg leading-relaxed line-clamp-4">
-          <RichTextRenderer
-            content={description}
-            contentFormat="markdown"
-            className="prose-invert"
-          />
-        </div>
-        <Dialog.Trigger asChild>
-          <button
-            type="button"
-            className="mt-3 text-[#37d6b5] underline text-sm font-semibold"
-          >
-            Ler manifesto completo →
-          </button>
-        </Dialog.Trigger>
-        <SaibaMaisLink />
+    <div className="flex flex-col">
+      <div className="opacity-85 text-base md:text-lg leading-relaxed line-clamp-4">
+        <RichTextRenderer
+          content={description}
+          contentFormat="markdown"
+          className="prose-invert"
+        />
       </div>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[60]" />
-        <Dialog.Content
-          className="
-            fixed top-0 right-0 h-full w-full md:w-[520px] z-[70] bg-white text-marine
-            shadow-2xl overflow-y-auto p-8 outline-none
-          "
-        >
-          <Dialog.Title className="text-2xl font-bold mb-4">
-            Quem somos
-          </Dialog.Title>
-          <Dialog.Description asChild>
-            <div className="prose">
-              <RichTextRenderer content={description} contentFormat="markdown" />
-            </div>
-          </Dialog.Description>
-          <Dialog.Close className="absolute top-4 right-4 text-marine">
-            ✕
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+      <Link
+        to={QUEM_SOMOS_PATH}
+        className="inline-flex items-center gap-2 mt-4 rounded-full px-6 py-2.5 text-sm font-semibold bg-[#37d6b5] text-[#0b2747] hover:bg-[#2bbfa1] hover:-translate-y-0.5 transition-all duration-200 shadow-md self-start"
+      >
+        Saiba mais →
+      </Link>
+    </div>
   );
 }

--- a/src/pages/homeV2/sections/AboutSection/index.tsx
+++ b/src/pages/homeV2/sections/AboutSection/index.tsx
@@ -7,14 +7,14 @@ import { AboutVideoCard } from "./AboutVideoCard";
 
 export const AboutSection: SectionComponent<AboutSectionData> = ({ data }) => {
   return (
-    <div className="relative overflow-hidden">
+    <div className="relative overflow-hidden pb-24 md:pb-32">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute -top-40 -right-32 h-[460px] w-[460px] rounded-full blur-3xl opacity-40"
         style={{ background: "#37d6b5" }}
       />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 relative">
-        <div className="px-4 py-12 md:py-16 max-w-2xl md:ml-auto flex flex-col justify-center">
+        <div className="px-4 pt-12 md:pt-16 pb-4 max-w-2xl md:ml-auto flex flex-col justify-center">
           <p className="home-section__eyebrow mb-3">{data.eyebrow}</p>
           <motion.h2
             initial={{ opacity: 0, y: 20 }}
@@ -27,7 +27,7 @@ export const AboutSection: SectionComponent<AboutSectionData> = ({ data }) => {
           </motion.h2>
           <AboutDescription description={data.description} />
         </div>
-        <div className="flex items-center justify-center py-8 md:py-12 px-4 md:mr-auto w-full">
+        <div className="flex items-center justify-center pt-8 md:pt-12 pb-4 px-4 md:mr-auto w-full">
           <div className="w-full max-w-lg aspect-video max-h-[380px]">
             <AboutVideoCard thumbnail={data.thumbnail} videoId={data.videoId} />
           </div>

--- a/src/pages/quemSomos/NossosValores.tsx
+++ b/src/pages/quemSomos/NossosValores.tsx
@@ -34,9 +34,9 @@ function ValorCard({
   children: ReactNode;
 }) {
   return (
-    <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-full aspect-[572/328] flex flex-col">
+    <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-full md:aspect-[572/328] flex flex-col">
       <div className="h-2 shrink-0" style={{ background: accent }} />
-      <div className="flex-1 px-10 py-6 flex flex-col justify-center">
+      <div className="flex-1 px-6 py-6 md:px-10 flex flex-col justify-center">
         <div
           className="w-14 h-14 rounded-full flex items-center justify-center mb-4"
           style={{ background: accent }}

--- a/src/pages/quemSomos/NossosValores.tsx
+++ b/src/pages/quemSomos/NossosValores.tsx
@@ -89,12 +89,12 @@ export function NossosValores() {
     <div className="relative bg-white py-20 md:py-28 flex flex-col gap-16 overflow-hidden">
       {/* Triângulo decorativo canto superior esquerdo */}
       <div
-        className="absolute top-0 left-0 w-40 h-40 pointer-events-none"
+        className="absolute top-0 left-0 w-20 h-20 sm:w-28 sm:h-28 md:w-32 md:h-32 lg:w-40 lg:h-40 pointer-events-none"
         style={{ background: "#D96B45", clipPath: "polygon(0 0, 100% 0, 0 100%)" }}
       />
       {/* Triângulo decorativo canto inferior direito */}
       <div
-        className="absolute bottom-0 right-0 w-40 h-40 pointer-events-none"
+        className="absolute bottom-0 right-0 w-20 h-20 sm:w-28 sm:h-28 md:w-32 md:h-32 lg:w-40 lg:h-40 pointer-events-none"
         style={{ background: "#D9AF45", clipPath: "polygon(100% 0, 100% 100%, 0 100%)" }}
       />
       <div className="container mx-auto px-4 text-center">

--- a/src/pages/quemSomos/index.tsx
+++ b/src/pages/quemSomos/index.tsx
@@ -67,7 +67,7 @@ export default function QuemSomosPage() {
       <div className="relative bg-white overflow-hidden">
         {/* Triângulo decorativo canto superior esquerdo */}
         <div
-          className="absolute top-0 left-0 w-40 h-40 pointer-events-none"
+          className="absolute top-0 left-0 w-20 h-20 sm:w-28 sm:h-28 md:w-32 md:h-32 lg:w-40 lg:h-40 pointer-events-none"
           style={{ background: "#8CC408", clipPath: "polygon(0 0, 100% 0, 0 100%)" }}
         />
 

--- a/src/pages/quemSomos/index.tsx
+++ b/src/pages/quemSomos/index.tsx
@@ -72,10 +72,10 @@ export default function QuemSomosPage() {
         />
 
         {/* Seção: Quem Somos */}
-        <div className="max-w-3xl mx-auto px-6 pt-16">
+        <div className="max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl mx-auto px-6 pt-16">
           <Text size="secondary">Quem Somos?</Text>
-          <div className="prose prose-xl max-w-none">
-            <RichTextRenderer content={data.description} contentFormat="markdown" className="text-marine text-base" />
+          <div className="prose prose-xl max-w-none text-justify">
+            <RichTextRenderer content={data.description} contentFormat="markdown" className="text-marine text-base text-justify" />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Branch evoluiu além do escopo original. Resumo das mudanças contidas nesta PR:

### Home (HomeV2) e Quem Somos
- **AboutSection (Home)**: aumenta o padding-bottom (`pb-24 md:pb-32`) pra balancear o espaço com a Hero. Remove os botões "Ler mais" / "Ler menos" / "Ler manifesto completo" e o drawer Radix associado. Preview agora fica em `line-clamp-4` e texto completo é lido em `/quem-somos` via "Saiba mais".

### Quem Somos
- **Descrição**: largura responsiva (`max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl`) e `text-justify`.
- **Triângulos decorativos**: escala responsiva (`w-20` → `sm:w-28` → `md:w-32` → `lg:w-40`), aplicado nos 3 triângulos.
- **NossosValores cards (mobile)**: remove `aspect-[572/328]` fixo em mobile (mantém só em `md:` onde sobrepõe a imagem) e reduz `px-10` → `px-6 md:px-10`. Texto não corta mais em telas pequenas.

### Dashboard de Home — Apoiadores
- **Upload de logo flexível**: `PhotoEditor` ganha prop opcional `aspectPresets` com chips clicáveis pra trocar proporção em tempo real.
- Preset sem `aspect` usa proporção natural da imagem (modo "Original/livre"); preset sem `targetSize` preserva pixel-size do crop.
- `ModalEditSupporter` passa 6 presets: 1:1 (quadrado, 600×600), 4:3, 16:9, 3:4, 9:16, Original (livre).

## Test plan
- [ ] `npm run dev` e abrir `/` — Home com mais respiro abaixo da AboutSection; só "Saiba mais" (sem "Ler mais").
- [ ] Abrir `/quem-somos` — texto justificado e largura responsiva; triângulos não sobrepõem mais em mobile/tablet; cards de Visão/Missão/Valores mostram texto inteiro em mobile.
- [ ] `/dashboard/dash-home` → aba Apoiadores → criar/editar apoiador → upload de logo → testar trocar entre os presets (1:1, 4:3, 16:9, 3:4, 9:16, Original).
- [ ] Verificar responsividade mobile/desktop nas páginas públicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)