### PR TITLE
feat(banco-questoes): ordenar filtros Prova, Matéria e Frente alfabeticamente

### DIFF
--- a/src/pages/dashQuestionNew/components/QuestionFilters.tsx
+++ b/src/pages/dashQuestionNew/components/QuestionFilters.tsx
@@ -56,8 +56,9 @@ export function QuestionFilters({
     // Lógica de cascata
     if (key === "enemArea") {
       // Filtrar matérias pela área ENEM
-      const materias =
-        infos?.materias?.filter((mat: any) => mat.enemArea === value) || [];
+      const materias = (
+        infos?.materias?.filter((mat: any) => mat.enemArea === value) || []
+      ).sort((a: any, b: any) => a.nome.localeCompare(b.nome, "pt-BR"));
       setMateriasFiltradas(materias);
       newFilters.materia = "";
       newFilters.frente = "";
@@ -67,7 +68,11 @@ export function QuestionFilters({
     if (key === "materia") {
       // Filtrar frentes pela matéria
       const materia = infos?.materias?.find((m: any) => m._id === value);
-      setFrentesFiltradas(materia?.frentes || []);
+      setFrentesFiltradas(
+        (materia?.frentes || []).sort((a: any, b: any) =>
+          a.nome.localeCompare(b.nome, "pt-BR")
+        )
+      );
       newFilters.frente = "";
     }
 
@@ -180,11 +185,13 @@ export function QuestionFilters({
                 <SelectValue placeholder="Todas as provas" />
               </SelectTrigger>
               <SelectContent>
-                {infos?.provas?.map((prova: any) => (
-                  <SelectItem key={prova._id} value={prova._id}>
-                    {prova.nome}
-                  </SelectItem>
-                ))}
+                {[...(infos?.provas || [])]
+                  .sort((a: any, b: any) => a.nome.localeCompare(b.nome, "pt-BR"))
+                  .map((prova: any) => (
+                    <SelectItem key={prova._id} value={prova._id}>
+                      {prova.nome}
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary

- Filtros **Prova**, **Matéria** e **Frente** agora são exibidos em ordem alfabética
- **Prova**: ordenação no render com spread + `.sort()` (não muta a prop)
- **Matéria**: ordenação ao popular a lista na lógica de cascata (ao selecionar Área do ENEM)
- **Frente**: ordenação ao popular a lista na lógica de cascata (ao selecionar Matéria)
- **Área do ENEM**: já tinha `.sort()` — sem alteração necessária
- Todos os sorts usam `localeCompare('pt-BR')` para respeitar acentuação do português

## Test Plan

- [ ] Abrir Banco de Questões e verificar que o dropdown **Prova** lista as provas em ordem alfabética
- [ ] Selecionar uma Área do ENEM e verificar que **Matéria** aparece em ordem alfabética
- [ ] Selecionar uma Matéria e verificar que **Frente** aparece em ordem alfabética

🤖 Generated with [Claude Code](https://claude.com/claude-code)