### PR TITLE
fix(chat): correções no widget de suporte ao aluno

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -18,7 +18,10 @@ import {
 import { useChatContext } from "@/context/ChatProvider";
 import { CHAT_ENABLED_ROUTES } from "@/routes/chatEnabledRoutes";
 import { markRead } from "@/services/chat/markRead";
-import { openConversation } from "@/services/chat/openConversation";
+import {
+  CooldownError,
+  openConversation,
+} from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 import { ChatLayout } from "./ChatLayout";
@@ -51,6 +54,7 @@ export function ChatWidget() {
   const opening = useChatStore((s) => s.isOpening);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [chatClosed, setChatClosed] = useState(false);
+  const [cooldown, setCooldown] = useState<number | null>(null);
   const [device, setDevice] = useState<"mobile" | "desktop">(detectDevice);
   const prevActiveRef = useRef<typeof active>(null);
   const { pathname } = useLocation();
@@ -83,6 +87,20 @@ export function ChatWidget() {
     prevActiveRef.current = active;
   }, [active, isOpen]);
 
+  useEffect(() => {
+    if (!cooldown || cooldown <= 0) return;
+    const id = setInterval(() => {
+      setCooldown((s) => {
+        if (s === null || s <= 1) {
+          clearInterval(id);
+          return null;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cooldown]);
+
   const hasPending =
     !!active &&
     (active.unreadCountStudent ?? 0) > 0 &&
@@ -100,7 +118,7 @@ export function ChatWidget() {
     prevPendingRef.current = hasPending;
   }, [hasPending]);
 
-  const shouldRender = routeEnabled || !!active || chatClosed;
+  const shouldRender = routeEnabled || !!active || chatClosed || cooldown !== null;
   if (role !== "student") return null;
   if (!shouldRender) return null;
 
@@ -134,9 +152,13 @@ export function ChatWidget() {
       setConfirmOpen(false);
       setOpen(true);
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "Falha ao abrir conversa";
-      toast.error(message);
+      if (e instanceof CooldownError) {
+        setConfirmOpen(false);
+        setCooldown(e.retryAfterSeconds);
+        setOpen(true);
+      } else {
+        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      }
     } finally {
       setOpening(false);
     }
@@ -169,10 +191,17 @@ export function ChatWidget() {
     </Button>
   );
 
+  function formatCountdown(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`;
+  }
+
   function handleWidgetClose() {
     setOpen(false);
     setActive(null);
     setChatClosed(false);
+    setCooldown(null);
   }
 
   const panel = chatClosed ? (
@@ -184,6 +213,15 @@ export function ChatWidget() {
       <Button variant="outline" size="sm" onClick={handleWidgetClose}>
         Fechar
       </Button>
+    </div>
+  ) : cooldown !== null ? (
+    <div className="flex flex-col items-center justify-center h-full p-6 gap-3 text-center">
+      <span className="text-2xl font-bold font-mono text-marine">
+        {formatCountdown(cooldown)}
+      </span>
+      <p className="text-xs text-muted-foreground">
+        Aguarde para iniciar uma nova conversa
+      </p>
     </div>
   ) : active && userId ? (
     <div className="h-full w-full">
@@ -206,7 +244,7 @@ export function ChatWidget() {
         loading={opening}
       />
       {device === "mobile" ? (
-        <Sheet open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
+        <Sheet open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) { setChatClosed(false); setCooldown(null); } }}>
           <SheetContent side="bottom" className="h-[85vh] p-0 flex flex-col">
             <SheetHeader className="sr-only">
               <SheetTitle>Suporte Você na Facul</SheetTitle>
@@ -218,7 +256,7 @@ export function ChatWidget() {
           </SheetContent>
         </Sheet>
       ) : (
-        <Popover open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
+        <Popover open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) { setChatClosed(false); setCooldown(null); } }}>
           <PopoverTrigger asChild>
             <span
               className="fixed bottom-6 right-6 h-14 w-14 pointer-events-none"

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -50,7 +50,9 @@ export function ChatWidget() {
   const setOpening = useChatStore((s) => s.setOpening);
   const opening = useChatStore((s) => s.isOpening);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [chatClosed, setChatClosed] = useState(false);
   const [device, setDevice] = useState<"mobile" | "desktop">(detectDevice);
+  const prevActiveRef = useRef<typeof active>(null);
   const { pathname } = useLocation();
   const matchedRoute = CHAT_ENABLED_ROUTES.find((r) =>
     matchPath({ path: r.pattern, end: true }, pathname)
@@ -71,6 +73,16 @@ export function ChatWidget() {
     }
   }, [isOpen, active, jwt]);
 
+  useEffect(() => {
+    if (prevActiveRef.current && !active && isOpen) {
+      setChatClosed(true);
+    }
+    if (active) {
+      setChatClosed(false);
+    }
+    prevActiveRef.current = active;
+  }, [active, isOpen]);
+
   const hasPending =
     !!active &&
     (active.unreadCountStudent ?? 0) > 0 &&
@@ -88,7 +100,7 @@ export function ChatWidget() {
     prevPendingRef.current = hasPending;
   }, [hasPending]);
 
-  const shouldRender = routeEnabled || !!active;
+  const shouldRender = routeEnabled || !!active || chatClosed;
   if (role !== "student") return null;
   if (!shouldRender) return null;
 
@@ -157,20 +169,32 @@ export function ChatWidget() {
     </Button>
   );
 
-  const panel =
-    active && userId ? (
-      <div className="h-full w-full">
-        <ChatLayout
-          conversationId={active.id}
-          currentUserId={userId}
-          title="Suporte Você na Facul"
-          onClose={() => {
-            setOpen(false);
-            setActive(null);
-          }}
-        />
-      </div>
-    ) : null;
+  function handleWidgetClose() {
+    setOpen(false);
+    setActive(null);
+    setChatClosed(false);
+  }
+
+  const panel = chatClosed ? (
+    <div className="flex flex-col items-center justify-center h-full p-6 gap-4 text-center">
+      <p className="text-sm text-muted-foreground">
+        Esta conversa foi encerrada. Se precisar de mais ajuda, você pode abrir
+        uma nova conversa.
+      </p>
+      <Button variant="outline" size="sm" onClick={handleWidgetClose}>
+        Fechar
+      </Button>
+    </div>
+  ) : active && userId ? (
+    <div className="h-full w-full">
+      <ChatLayout
+        conversationId={active.id}
+        currentUserId={userId}
+        title="Suporte Você na Facul"
+        onClose={handleWidgetClose}
+      />
+    </div>
+  ) : null;
 
   return (
     <>
@@ -182,7 +206,7 @@ export function ChatWidget() {
         loading={opening}
       />
       {device === "mobile" ? (
-        <Sheet open={isOpen} onOpenChange={setOpen}>
+        <Sheet open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
           <SheetContent side="bottom" className="h-[85vh] p-0 flex flex-col">
             <SheetHeader className="sr-only">
               <SheetTitle>Suporte Você na Facul</SheetTitle>
@@ -194,7 +218,7 @@ export function ChatWidget() {
           </SheetContent>
         </Sheet>
       ) : (
-        <Popover open={isOpen} onOpenChange={setOpen}>
+        <Popover open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
           <PopoverTrigger asChild>
             <span
               className="fixed bottom-6 right-6 h-14 w-14 pointer-events-none"

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -164,7 +164,7 @@ export function ChatWidget() {
         setCooldownUntil(Date.now() + e.retryAfterSeconds * 1000);
         setOpen(true);
         toast.info(
-          `Não é possível abrir o chat no momento. Aguarde ${formatCountdown(e.retryAfterSeconds)} para iniciar uma nova conversa.`,
+          "Aguarde um instante para abrir uma nova sessão.",
         );
       } else {
         toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -18,7 +18,10 @@ import {
 import { useChatContext } from "@/context/ChatProvider";
 import { CHAT_ENABLED_ROUTES } from "@/routes/chatEnabledRoutes";
 import { markRead } from "@/services/chat/markRead";
-import { openConversation } from "@/services/chat/openConversation";
+import {
+  CooldownError,
+  openConversation,
+} from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 import { ChatLayout } from "./ChatLayout";
@@ -56,6 +59,7 @@ export function ChatWidget() {
   const setOpening = useChatStore((s) => s.setOpening);
   const opening = useChatStore((s) => s.isOpening);
   const cooldownUntil = useChatStore((s) => s.cooldownUntil);
+  const setCooldownUntil = useChatStore((s) => s.setCooldownUntil);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [chatClosed, setChatClosed] = useState(false);
   const [remainingSeconds, setRemainingSeconds] = useState(0);
@@ -155,7 +159,16 @@ export function ChatWidget() {
       setConfirmOpen(false);
       setOpen(true);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      if (e instanceof CooldownError) {
+        setConfirmOpen(false);
+        setCooldownUntil(Date.now() + e.retryAfterSeconds * 1000);
+        setOpen(true);
+        toast.info(
+          `Não é possível abrir o chat no momento. Aguarde ${formatCountdown(e.retryAfterSeconds)} para iniciar uma nova conversa.`,
+        );
+      } else {
+        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      }
     } finally {
       setOpening(false);
     }

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -18,10 +18,7 @@ import {
 import { useChatContext } from "@/context/ChatProvider";
 import { CHAT_ENABLED_ROUTES } from "@/routes/chatEnabledRoutes";
 import { markRead } from "@/services/chat/markRead";
-import {
-  CooldownError,
-  openConversation,
-} from "@/services/chat/openConversation";
+import { openConversation } from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 import { ChatLayout } from "./ChatLayout";
@@ -31,6 +28,12 @@ import { UnreadBadge } from "./UnreadBadge";
 function detectDevice(): "mobile" | "desktop" {
   if (typeof window === "undefined") return "desktop";
   return window.matchMedia("(max-width: 768px)").matches ? "mobile" : "desktop";
+}
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`;
 }
 
 function detectBrowser(): string {
@@ -52,9 +55,10 @@ export function ChatWidget() {
   const setActive = useChatStore((s) => s.setActiveConversation);
   const setOpening = useChatStore((s) => s.setOpening);
   const opening = useChatStore((s) => s.isOpening);
+  const cooldownUntil = useChatStore((s) => s.cooldownUntil);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [chatClosed, setChatClosed] = useState(false);
-  const [cooldown, setCooldown] = useState<number | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
   const [device, setDevice] = useState<"mobile" | "desktop">(detectDevice);
   const prevActiveRef = useRef<typeof active>(null);
   const { pathname } = useLocation();
@@ -88,18 +92,16 @@ export function ChatWidget() {
   }, [active, isOpen]);
 
   useEffect(() => {
-    if (!cooldown || cooldown <= 0) return;
+    if (!cooldownUntil) { setRemainingSeconds(0); return; }
+    const compute = () => Math.max(0, Math.ceil((cooldownUntil - Date.now()) / 1000));
+    setRemainingSeconds(compute());
     const id = setInterval(() => {
-      setCooldown((s) => {
-        if (s === null || s <= 1) {
-          clearInterval(id);
-          return null;
-        }
-        return s - 1;
-      });
+      const r = compute();
+      setRemainingSeconds(r);
+      if (r <= 0) clearInterval(id);
     }, 1000);
     return () => clearInterval(id);
-  }, [cooldown]);
+  }, [cooldownUntil]);
 
   const hasPending =
     !!active &&
@@ -118,13 +120,14 @@ export function ChatWidget() {
     prevPendingRef.current = hasPending;
   }, [hasPending]);
 
-  const shouldRender = routeEnabled || !!active || chatClosed || cooldown !== null;
+  const shouldRender = routeEnabled || !!active || chatClosed || remainingSeconds > 0;
   if (role !== "student") return null;
   if (!shouldRender) return null;
 
   function handleClick() {
-    if (active) {
-      setOpen(true);
+    if (active) { setOpen(true); return; }
+    if (remainingSeconds > 0) {
+      toast.info(`Aguarde ${formatCountdown(remainingSeconds)} para iniciar uma nova conversa`);
       return;
     }
     setConfirmOpen(true);
@@ -152,13 +155,7 @@ export function ChatWidget() {
       setConfirmOpen(false);
       setOpen(true);
     } catch (e) {
-      if (e instanceof CooldownError) {
-        setConfirmOpen(false);
-        setCooldown(e.retryAfterSeconds);
-        setOpen(true);
-      } else {
-        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
-      }
+      toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
     } finally {
       setOpening(false);
     }
@@ -191,17 +188,10 @@ export function ChatWidget() {
     </Button>
   );
 
-  function formatCountdown(seconds: number): string {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`;
-  }
-
   function handleWidgetClose() {
     setOpen(false);
     setActive(null);
     setChatClosed(false);
-    setCooldown(null);
   }
 
   const panel = chatClosed ? (
@@ -210,18 +200,20 @@ export function ChatWidget() {
         Esta conversa foi encerrada. Se precisar de mais ajuda, você pode abrir
         uma nova conversa.
       </p>
-      <Button variant="outline" size="sm" onClick={handleWidgetClose}>
-        Fechar
-      </Button>
-    </div>
-  ) : cooldown !== null ? (
-    <div className="flex flex-col items-center justify-center h-full p-6 gap-3 text-center">
-      <span className="text-2xl font-bold font-mono text-marine">
-        {formatCountdown(cooldown)}
-      </span>
-      <p className="text-xs text-muted-foreground">
-        Aguarde para iniciar uma nova conversa
-      </p>
+      {remainingSeconds > 0 ? (
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-2xl font-bold font-mono text-marine">
+            {formatCountdown(remainingSeconds)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            Aguarde para iniciar uma nova conversa
+          </span>
+        </div>
+      ) : (
+        <Button size="sm" onClick={() => { setChatClosed(false); setConfirmOpen(true); }}>
+          Iniciar nova conversa
+        </Button>
+      )}
     </div>
   ) : active && userId ? (
     <div className="h-full w-full">
@@ -244,7 +236,7 @@ export function ChatWidget() {
         loading={opening}
       />
       {device === "mobile" ? (
-        <Sheet open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) { setChatClosed(false); setCooldown(null); } }}>
+        <Sheet open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
           <SheetContent side="bottom" className="h-[85vh] p-0 flex flex-col">
             <SheetHeader className="sr-only">
               <SheetTitle>Suporte Você na Facul</SheetTitle>
@@ -256,7 +248,7 @@ export function ChatWidget() {
           </SheetContent>
         </Sheet>
       ) : (
-        <Popover open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) { setChatClosed(false); setCooldown(null); } }}>
+        <Popover open={isOpen} onOpenChange={(v) => { setOpen(v); if (!v) setChatClosed(false); }}>
           <PopoverTrigger asChild>
             <span
               className="fixed bottom-6 right-6 h-14 w-14 pointer-events-none"

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -234,6 +234,7 @@ export function ChatWidget() {
         conversationId={active.id}
         currentUserId={userId}
         title="Suporte Você na Facul"
+        status={active.status}
         onClose={handleWidgetClose}
       />
     </div>

--- a/src/context/ChatProvider.tsx
+++ b/src/context/ChatProvider.tsx
@@ -9,7 +9,10 @@ import React, {
 } from "react";
 import { signInFirebase, signOutFirebase } from "@/services/firebase/auth";
 import { getFirebaseToken } from "@/services/chat/getFirebaseToken";
-import { listenStudentActiveConversation } from "@/services/firebase/conversations";
+import {
+  listenStudentActiveConversation,
+  listenStudentCooldown,
+} from "@/services/firebase/conversations";
 import { useChatStore } from "@/store/chatStore";
 import { useAuthStore } from "@/store/auth";
 import { jwtDecoded } from "@/utils/jwt";
@@ -35,9 +38,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const setAuthed = useChatStore((s) => s.setFirebaseAuthed);
   const setActive = useChatStore((s) => s.setActiveConversation);
   const setPartnerPrepId = useChatStore((s) => s.setPartnerPrepId);
+  const setCooldownUntil = useChatStore((s) => s.setCooldownUntil);
   const [role, setRole] = useState<Role>(null);
   const [userId, setUserId] = useState<string | null>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
+  const unsubCooldownRef = useRef<(() => void) | null>(null);
 
   const jwt = data?.token;
   const isSupport =
@@ -60,8 +65,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       if (!decodedId) {
         unsubscribeRef.current?.();
         unsubscribeRef.current = null;
+        unsubCooldownRef.current?.();
+        unsubCooldownRef.current = null;
         setAuthed(false);
         setActive(null);
+        setCooldownUntil(null);
         setRole(null);
         setUserId(null);
         setPartnerPrepId(null);
@@ -97,6 +105,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             decodedId,
             (conv) => setActive(conv),
           );
+          unsubCooldownRef.current?.();
+          unsubCooldownRef.current = listenStudentCooldown(
+            decodedId,
+            (until) => setCooldownUntil(until),
+          );
         }
       } catch (err) {
         console.error("[ChatProvider] bootstrap failed", err);
@@ -107,8 +120,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       cancelled = true;
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
+      unsubCooldownRef.current?.();
+      unsubCooldownRef.current = null;
     };
-  }, [decodedId, isSupport, setAuthed, setActive, setPartnerPrepId]);
+  }, [decodedId, isSupport, setAuthed, setActive, setPartnerPrepId, setCooldownUntil]);
 
   const active = useChatStore((s) => s.activeConversation);
   const studentUnread =

--- a/src/context/ChatProvider.tsx
+++ b/src/context/ChatProvider.tsx
@@ -92,10 +92,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         setUserId(decodedId);
 
         // Extract partnerPrepId from Firebase ID token claims
+        let partnerPrepIdValue: string | null = null;
         const auth = getFirebaseAuth();
         if (auth.currentUser) {
           const idTokenResult = await auth.currentUser.getIdTokenResult();
-          const partnerPrepIdValue = (idTokenResult.claims.partnerPrepId as string) ?? null;
+          partnerPrepIdValue = (idTokenResult.claims.partnerPrepId as string) ?? null;
           setPartnerPrepId(partnerPrepIdValue);
         }
 
@@ -108,6 +109,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           unsubCooldownRef.current?.();
           unsubCooldownRef.current = listenStudentCooldown(
             decodedId,
+            partnerPrepIdValue,
             (until) => setCooldownUntil(until),
           );
         }

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -68,7 +68,7 @@ export default function SupportPage() {
         setConfirmOpen(false);
         setCooldownUntil(Date.now() + e.retryAfterSeconds * 1000);
         toast.info(
-          `Não é possível abrir o chat no momento. Aguarde ${formatCountdown(e.retryAfterSeconds)} para iniciar uma nova conversa.`,
+          "Aguarde um instante para abrir uma nova sessão.",
         );
       } else {
         toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -5,7 +5,10 @@ import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ConfirmOpenDialog } from "@/components/chat/ConfirmOpenDialog";
 import { Button } from "@/components/ui/button";
 import { useChatContext } from "@/context/ChatProvider";
-import { openConversation } from "@/services/chat/openConversation";
+import {
+  CooldownError,
+  openConversation,
+} from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 
@@ -18,6 +21,7 @@ function formatCountdown(seconds: number): string {
 export default function SupportPage() {
   const active = useChatStore((s) => s.activeConversation);
   const cooldownUntil = useChatStore((s) => s.cooldownUntil);
+  const setCooldownUntil = useChatStore((s) => s.setCooldownUntil);
   const { userId } = useChatContext();
   const jwt = useAuthStore((s) => s.data.token);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -60,7 +64,15 @@ export default function SupportPage() {
       setConfirmOpen(false);
       setClosedBySupport(false);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      if (e instanceof CooldownError) {
+        setConfirmOpen(false);
+        setCooldownUntil(Date.now() + e.retryAfterSeconds * 1000);
+        toast.info(
+          `Não é possível abrir o chat no momento. Aguarde ${formatCountdown(e.retryAfterSeconds)} para iniciar uma nova conversa.`,
+        );
+      } else {
+        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -5,10 +5,7 @@ import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ConfirmOpenDialog } from "@/components/chat/ConfirmOpenDialog";
 import { Button } from "@/components/ui/button";
 import { useChatContext } from "@/context/ChatProvider";
-import {
-  CooldownError,
-  openConversation,
-} from "@/services/chat/openConversation";
+import { openConversation } from "@/services/chat/openConversation";
 import { useAuthStore } from "@/store/auth";
 import { useChatStore } from "@/store/chatStore";
 
@@ -20,12 +17,13 @@ function formatCountdown(seconds: number): string {
 
 export default function SupportPage() {
   const active = useChatStore((s) => s.activeConversation);
+  const cooldownUntil = useChatStore((s) => s.cooldownUntil);
   const { userId } = useChatContext();
   const jwt = useAuthStore((s) => s.data.token);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [closedBySupport, setClosedBySupport] = useState(false);
-  const [cooldown, setCooldown] = useState<number | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
   const prevActiveRef = useRef(active);
 
   useEffect(() => {
@@ -36,18 +34,16 @@ export default function SupportPage() {
   }, [active]);
 
   useEffect(() => {
-    if (!cooldown || cooldown <= 0) return;
+    if (!cooldownUntil) { setRemainingSeconds(0); return; }
+    const compute = () => Math.max(0, Math.ceil((cooldownUntil - Date.now()) / 1000));
+    setRemainingSeconds(compute());
     const id = setInterval(() => {
-      setCooldown((s) => {
-        if (s === null || s <= 1) {
-          clearInterval(id);
-          return null;
-        }
-        return s - 1;
-      });
+      const r = compute();
+      setRemainingSeconds(r);
+      if (r <= 0) clearInterval(id);
     }, 1000);
     return () => clearInterval(id);
-  }, [cooldown]);
+  }, [cooldownUntil]);
 
   async function handleConfirm() {
     if (!jwt) return;
@@ -63,14 +59,8 @@ export default function SupportPage() {
       });
       setConfirmOpen(false);
       setClosedBySupport(false);
-      setCooldown(null);
     } catch (e) {
-      if (e instanceof CooldownError) {
-        setConfirmOpen(false);
-        setCooldown(e.retryAfterSeconds);
-      } else {
-        toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
-      }
+      toast.error(e instanceof Error ? e.message : "Falha ao abrir conversa");
     } finally {
       setLoading(false);
     }
@@ -96,10 +86,10 @@ export default function SupportPage() {
             Esta conversa foi encerrada. Se precisar de mais ajuda, você pode
             abrir uma nova conversa.
           </span>
-          {cooldown !== null ? (
+          {remainingSeconds > 0 ? (
             <div className="flex flex-col items-center gap-1">
               <span className="text-2xl font-bold font-mono text-marine">
-                {formatCountdown(cooldown)}
+                {formatCountdown(remainingSeconds)}
               </span>
               <span className="text-xs text-grey">
                 Aguarde para iniciar uma nova conversa

--- a/src/services/firebase/conversations.ts
+++ b/src/services/firebase/conversations.ts
@@ -10,6 +10,8 @@ import {
 } from "firebase/firestore";
 import { getFirestoreDb } from "./client";
 
+export const CHAT_COOLDOWN_MS = 15 * 60 * 1000;
+
 export interface ConversationDoc {
   id: string;
   userId: string;
@@ -25,6 +27,7 @@ export interface ConversationDoc {
   partnerPrepId?: string | null;
   cursinhoName?: string | null;
   originLabel?: string | null;
+  closedAt?: { toMillis: () => number } | null;
 }
 
 export function listenStudentActiveConversation(
@@ -49,6 +52,38 @@ export function listenStudentActiveConversation(
     },
     (err) => {
       console.warn("[firestore listener]", err.code ?? err.message);
+    },
+  );
+}
+
+export function listenStudentCooldown(
+  userId: string,
+  cb: (cooldownUntil: number | null) => void,
+): Unsubscribe {
+  const q = query(
+    collection(getFirestoreDb(), "conversations"),
+    where("userId", "==", userId),
+    where("status", "==", "closed"),
+    orderBy("closedAt", "desc"),
+    limit(1),
+  );
+  return onSnapshot(
+    q,
+    (snap) => {
+      if (snap.empty) {
+        cb(null);
+        return;
+      }
+      const closedAtMs = snap.docs[0].data().closedAt?.toMillis?.() ?? null;
+      if (closedAtMs === null) {
+        cb(null);
+        return;
+      }
+      const until = closedAtMs + CHAT_COOLDOWN_MS;
+      cb(until > Date.now() ? until : null);
+    },
+    (err) => {
+      console.warn("[firestore cooldown listener]", err.code ?? err.message);
     },
   );
 }

--- a/src/services/firebase/conversations.ts
+++ b/src/services/firebase/conversations.ts
@@ -58,12 +58,14 @@ export function listenStudentActiveConversation(
 
 export function listenStudentCooldown(
   userId: string,
+  partnerPrepId: string | null,
   cb: (cooldownUntil: number | null) => void,
 ): Unsubscribe {
   const q = query(
     collection(getFirestoreDb(), "conversations"),
     where("userId", "==", userId),
     where("status", "==", "closed"),
+    where("partnerPrepId", "==", partnerPrepId),
     orderBy("closedAt", "desc"),
     limit(1),
   );

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -7,12 +7,14 @@ interface ChatState {
   isOpen: boolean;
   isOpening: boolean;
   partnerPrepId: string | null;
+  cooldownUntil: number | null;
 
   setFirebaseAuthed: (v: boolean) => void;
   setActiveConversation: (c: ConversationDoc | null) => void;
   setOpen: (v: boolean) => void;
   setOpening: (v: boolean) => void;
   setPartnerPrepId: (id: string | null) => void;
+  setCooldownUntil: (v: number | null) => void;
 }
 
 export const useChatStore = create<ChatState>((set) => ({
@@ -21,9 +23,11 @@ export const useChatStore = create<ChatState>((set) => ({
   isOpen: false,
   isOpening: false,
   partnerPrepId: null,
+  cooldownUntil: null,
   setFirebaseAuthed: (v) => set({ firebaseAuthed: v }),
   setActiveConversation: (c) => set({ activeConversation: c }),
   setOpen: (v) => set({ isOpen: v }),
   setOpening: (v) => set({ isOpening: v }),
   setPartnerPrepId: (id) => set({ partnerPrepId: id }),
+  setCooldownUntil: (v) => set({ cooldownUntil: v }),
 }));


### PR DESCRIPTION
## Summary

- **Tela em branco ao encerrar**: quando o suporte fechava a conversa, o Popover ficava aberto sem conteúdo. Agora detecta a transição `active → null` e exibe "Esta conversa foi encerrada. Se precisar de mais ajuda, você pode abrir uma nova conversa."
- **Cooldown calculado a partir do Firebase**: substituiu a abordagem baseada em HTTP 429 por um listener Firestore (`userId + status=closed + partnerPrepId + closedAt desc`) que calcula `cooldownUntil` em tempo real. O countdown aparece automaticamente ao fechar, sem precisar tentar abrir e falhar. Índice composto já existia em `firestore.indexes.json`.
- **Scoping por `partnerPrepId`**: cooldown agora é idêntico ao backend — cursinhos distintos não bloqueiam entre si.
- **Fallback HTTP 429**: quando o listener Firebase não detecta o cooldown (ex.: `partnerPrepId` diferente do claim JWT), o `CooldownError` do HTTP sincroniza o store e exibe toast genérico: "Aguarde um instante para abrir uma nova sessão."
- **Botão encerrar para o aluno**: `ChatWidget` não passava `status` para `ChatLayout`, por isso o botão "Encerrar" ficava escondido. Uma linha corrigiu isso.

## Test plan

- [ ] Suporte encerra a conversa → widget exibe mensagem de encerramento (não tela em branco)
- [ ] Após fechar, countdown aparece automaticamente (sem precisar clicar em nada)
- [ ] Countdown some e botão "Iniciar nova conversa" aparece ao expirar
- [ ] Clicar no botão flutuante durante cooldown exibe toast genérico
- [ ] Aluno com dois cursinhos distintos: cooldown de um não bloqueia o outro
- [ ] Aluno pode encerrar a própria conversa pelo botão "Encerrar" no widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)