### PR TITLE
feat(banco-questoes): número da questão opcional com botão remover

### DIFF
--- a/src/dtos/question/updateQuestion.ts
+++ b/src/dtos/question/updateQuestion.ts
@@ -5,7 +5,7 @@ export interface CreateQuestion {
   frente2?: string | null;
   frente3?: string | null;
   materia?: string;
-  numero: number;
+  numero?: number | null;
   textoQuestao?: string;
   pergunta?: string;
   textoAlternativaA?: string;

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
@@ -408,12 +408,27 @@ export function TabClassificacao({
 
             {/* Número */}
             <div className="space-y-2">
-              <label className="text-sm font-semibold text-gray-600">
-                Número da Questão *
-              </label>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-semibold text-gray-600">
+                  Número da Questão
+                </label>
+                {isEditing && form.watch("numero") != null && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => form.setValue("numero", null, { shouldDirty: true })}
+                    className="h-6 px-2 text-xs text-red-600 border-red-300 hover:text-red-700 hover:bg-red-50"
+                  >
+                    Remover número
+                  </Button>
+                )}
+              </div>
               {!isEditing ? (
                 <div className="p-3 bg-gray-50 rounded-md border border-gray-200">
-                  <p className="text-base">{question.numero}</p>
+                  <p className="text-base text-gray-400">
+                    {question.numero ?? "Sem número"}
+                  </p>
                 </div>
               ) : loadingNumeros ? (
                 <div className="flex items-center justify-center p-3 border border-gray-200 rounded-md bg-gray-50">
@@ -442,7 +457,7 @@ export function TabClassificacao({
                   control={control}
                   render={({ field }) => (
                     <Select
-                      value={field.value?.toString()}
+                      value={field.value != null ? field.value.toString() : undefined}
                       onValueChange={(value) => field.onChange(parseInt(value))}
                       disabled={!provaId || numerosDisponiveis.length === 0}
                     >

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/schema.ts
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/schema.ts
@@ -13,7 +13,8 @@ export const classificacaoSchema = yup.object({
 
   numero: yup
     .number()
-    .required("O número da questão é obrigatório")
+    .nullable()
+    .optional()
     .positive("O número deve ser positivo")
     .integer("O número deve ser um inteiro")
     .min(1, "O número deve ser maior que 0"),
@@ -56,7 +57,7 @@ export type ClassificacaoFormData = yup.InferType<typeof classificacaoSchema>;
  */
 export const classificacaoDefaultValues: Partial<ClassificacaoFormData> = {
   prova: "",
-  numero: 1,
+  numero: null,
   enemArea: "",
   materia: "",
   frente1: "",

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/useClassificacaoForm.ts
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/useClassificacaoForm.ts
@@ -39,7 +39,7 @@ export function useClassificacaoForm({
     resolver: yupResolver(classificacaoSchema),
     defaultValues: {
       prova: question.prova || "",
-      numero: question.numero || 1,
+      numero: question.numero ?? null,
       enemArea: question.enemArea || "",
       materia: question.materia || "",
       frente1: question.frente1 || "",
@@ -61,7 +61,7 @@ export function useClassificacaoForm({
     if (question) {
       form.reset({
         prova: question.prova || "",
-        numero: question.numero || 1,
+        numero: question.numero ?? null,
         enemArea: question.enemArea || "",
         materia: question.materia || "",
         frente1: question.frente1 || "",

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacaoCreate.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacaoCreate.tsx
@@ -48,11 +48,9 @@ export function TabClassificacaoCreate({
         try {
           const numeros = await getMissingNumber(formData.prova, token);
           setNumerosDisponiveis(numeros);
-          // Limpar o número selecionado se não estiver mais disponível
-          if (formData.numero && !numeros.includes(formData.numero)) {
-            onChange("numero", numeros[0] || 1);
-          } else if (numeros.length > 0 && !formData.numero) {
-            onChange("numero", numeros[0]);
+          // Limpar numero se o selecionado não está mais disponível
+          if (formData.numero != null && !numeros.includes(formData.numero)) {
+            onChange("numero", null);
           }
         } catch (error) {
           console.error("Erro ao buscar números disponíveis:", error);
@@ -116,7 +114,7 @@ export function TabClassificacaoCreate({
   const handleProvaChange = (value: string) => {
     onChange("prova", value);
     // Limpar campos dependentes
-    onChange("numero", 1); // Reset numero também
+    onChange("numero", null);
     onChange("enemArea", "");
     onChange("materia", "");
     onChange("frente1", "");
@@ -205,9 +203,22 @@ export function TabClassificacaoCreate({
 
             {/* Número */}
             <div className="space-y-2">
-              <label className="text-sm font-semibold text-gray-600">
-                Número da Questão *
-              </label>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-semibold text-gray-600">
+                  Número da Questão
+                </label>
+                {formData.numero != null && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onChange("numero", null)}
+                    className="h-6 px-2 text-xs text-red-600 border-red-300 hover:text-red-700 hover:bg-red-50"
+                  >
+                    Remover número
+                  </Button>
+                )}
+              </div>
               {loadingNumeros ? (
                 <div className="flex items-center justify-center p-3 border border-gray-200 rounded-md bg-gray-50">
                   <Loader2 className="h-4 w-4 animate-spin text-primary mr-2" />
@@ -232,7 +243,7 @@ export function TabClassificacaoCreate({
                 </div>
               ) : (
                 <Select
-                  value={formData.numero?.toString()}
+                  value={formData.numero != null ? formData.numero.toString() : undefined}
                   onValueChange={(value) => onChange("numero", parseInt(value))}
                   disabled={!formData.prova || numerosDisponiveis.length === 0}
                 >

--- a/src/services/question/updateClassification.ts
+++ b/src/services/question/updateClassification.ts
@@ -9,7 +9,7 @@ import { questoes } from "../urls";
 export interface UpdateClassificationData {
   _id: string;
   prova: string;
-  numero: number;
+  numero?: number | null;
   enemArea: string;
   materia: string;
   frente1: string;
@@ -33,9 +33,8 @@ export async function updateClassification(
 ): Promise<void> {
   const { _id, ...body } = data;
 
-  // Converter numero para number se vier como string
   if (typeof body.numero === "string") {
-    body.numero = parseInt(body.numero, 10);
+    body.numero = parseInt(body.numero, 10) || null;
   }
 
   const response = await fetchWrapper(`${questoes}/${_id}/classification`, {


### PR DESCRIPTION
## Summary
- `numero` passa a ser `number | null` nos DTOs e no schema Yup (nullable + optional)
- Botão "Remover número" aparece ao lado do label quando um número está selecionado (nos modos criar e editar)
- Clicar no botão seta `numero` para null com `shouldDirty: true`, habilitando o botão Salvar
- Modo visualização exibe "Sem número" quando `numero` é null
- Troca de prova reseta `numero` para null (sem auto-seleção do primeiro disponível)

## Motivation
Simplifica a troca de número entre questões: em vez de 4 operações, o usuário clica "Remover número" na questão que ocupa o slot desejado, salva, e atribui o número à questão certa.

## Test Plan
- [ ] Abrir edição de questão → clicar "Remover número" → botão Salvar habilita → salvar
- [ ] Criar nova questão → selecionar prova → sem auto-seleção de número → selecionar manualmente ou deixar sem número
- [ ] Questão sem número exibe "Sem número" no modo visualização
- [ ] TypeScript compila sem erros (`npx tsc --noEmit`)