### PR TITLE
feat(processo-seletivo-teste): melhora UX do modal de aviso e toast de matrícula

### DIFF
--- a/src/pages/partnerPrepInscriptionManager/index.tsx
+++ b/src/pages/partnerPrepInscriptionManager/index.tsx
@@ -37,6 +37,7 @@ export function PartnerPrepInscriptionManager() {
   >(undefined);
   const [pendingCreation, setPendingCreation] =
     useState<InscriptionOutput | null>(null);
+  const [testConfirmed, setTestConfirmed] = useState(false);
   const [statusFilter, setStatusFilter] = useState<StatusEnum>(StatusEnum.All);
   const limitCards = 100;
 
@@ -124,6 +125,7 @@ export function PartnerPrepInscriptionManager() {
   const handleCreate = async (data: InscriptionOutput) => {
     if (data.isTest) {
       setPendingCreation(data);
+      setTestConfirmed(false);
       modals.modalConfirmTest.open();
       return;
     }
@@ -158,6 +160,7 @@ export function PartnerPrepInscriptionManager() {
 
   const cancelTestCreation = () => {
     setPendingCreation(null);
+    setTestConfirmed(false);
     modals.modalConfirmTest.close();
   };
 
@@ -248,6 +251,17 @@ export function PartnerPrepInscriptionManager() {
               <strong>Nenhum estudante</strong> inscrito neste processo poderá ser matriculado.
             </li>
           </ul>
+          <label className="flex items-center gap-3 mb-6 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={testConfirmed}
+              onChange={(e) => setTestConfirmed(e.target.checked)}
+              className="w-4 h-4 accent-orange-500 cursor-pointer"
+            />
+            <span className="text-sm font-medium">
+              Entendi e quero continuar
+            </span>
+          </label>
           <div className="flex justify-end gap-4 sm:col-span-2 mt-2">
             <Button
               typeStyle="secondary"
@@ -260,6 +274,7 @@ export function PartnerPrepInscriptionManager() {
               typeStyle="primary"
               className="w-24 h-9"
               onClick={confirmTestCreation}
+              disabled={!testConfirmed}
             >
               Salvar
             </Button>

--- a/src/pages/partnerPrepInscriptionManager/index.tsx
+++ b/src/pages/partnerPrepInscriptionManager/index.tsx
@@ -232,14 +232,22 @@ export function PartnerPrepInscriptionManager() {
     return modals.modalConfirmTest.isOpen ? (
       <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
         <div className="bg-white p-6 rounded-xl w-[400px]">
-          <h2 className="text-lg font-semibold mb-4">
-            Confirmação de Processo de Teste
+          <h2 className="text-2xl font-bold mb-4 text-yellow-600">
+            Atenção
           </h2>
 
-          <p className="mb-6 text-sm">
-            Este processo será marcado como <strong>teste</strong> e não deve
-            ser considerado válido para uso real.
+          <p className="mb-6 text-sm leading-relaxed">
+            Você está criando um <strong>Processo Seletivo de Teste</strong>.
+            Leia com atenção antes de confirmar:
           </p>
+          <ul className="mb-6 text-sm leading-relaxed list-disc list-inside space-y-2">
+            <li>
+              Uma vez criado como teste, <strong>não é possível alterar para um Processo Seletivo normal</strong>.
+            </li>
+            <li>
+              <strong>Nenhum estudante</strong> inscrito neste processo poderá ser matriculado.
+            </li>
+          </ul>
           <div className="flex justify-end gap-4 sm:col-span-2 mt-2">
             <Button
               typeStyle="secondary"

--- a/src/pages/partnerPrepInscriptionManager/modals/InscriptionInfoCreateEditModal.tsx
+++ b/src/pages/partnerPrepInscriptionManager/modals/InscriptionInfoCreateEditModal.tsx
@@ -197,7 +197,7 @@ export function InscriptionInfoCreateEditModal({
               Cancelar
             </Button>
             <Button typeStyle="primary" className="w-24 h-9" type="submit">
-              Salvar
+              {isEdit ? "Salvar" : "Criar"}
             </Button>
           </div>
         </form>

--- a/src/pages/partnerPrepInscritionStudentManager/index.tsx
+++ b/src/pages/partnerPrepInscritionStudentManager/index.tsx
@@ -4,6 +4,7 @@ import { Bool } from "@/enums/bool";
 import { StatusApplication } from "@/enums/prepCourse/statusApplication";
 import { useModals } from "@/hooks/useModal";
 import { useToastAsync } from "@/hooks/useToastAsync";
+import { toast } from "react-toastify";
 import { getRuleSetByInscription } from "@/services/partnerPrepForm/getRuleSetByInscription";
 import { getInscription } from "@/services/prepCourse/getInscription";
 import { getSubscribers } from "@/services/prepCourse/inscription/getSubscribers";
@@ -217,26 +218,43 @@ export function PartnerPrepInscritionStudentManager() {
   const handleConfirmEnrolled = async (classId: string, className: string) => {
     if (!studentSelected) return;
 
-    await executeAsync({
-      action: () => confirmEnrolled(studentSelected.id, classId, token),
-      loadingMessage: "Confirmando Matrícula...",
-      successMessage: `Matrícula confirmada com sucesso na turma ${className}!`,
-      errorMessage: (error: Error) =>
-        `Erro ao confirmar matrícula: ${error.message}`,
-      onSuccess: () => {
-        const newStudent = students.map((stu) => {
-          if (stu.id === studentSelected.id) {
-            return {
-              ...stu,
-              status: StatusApplication.Enrolled,
-            };
-          }
-          return stu;
+    const toastId = toast.loading("Confirmando Matrícula...");
+    try {
+      await confirmEnrolled(studentSelected.id, classId, token);
+      toast.update(toastId, {
+        render: `Matrícula confirmada com sucesso na turma ${className}!`,
+        type: "success",
+        isLoading: false,
+        autoClose: 3000,
+        closeOnClick: true,
+      });
+      const newStudents = students.map((stu) =>
+        stu.id === studentSelected.id
+          ? { ...stu, status: StatusApplication.Enrolled }
+          : stu
+      );
+      setStudents(newStudents);
+      modals.selectClass.close();
+    } catch (error: unknown) {
+      if ((error as Error & { isTestPS?: boolean }).isTestPS) {
+        toast.update(toastId, {
+          render: "Processo Seletivo de Teste: Não é possível matricular estudantes",
+          type: "default",
+          theme: "dark",
+          isLoading: false,
+          autoClose: 5000,
+          closeOnClick: true,
         });
-        setStudents(newStudent);
-        modals.selectClass.close();
-      },
-    });
+      } else {
+        toast.update(toastId, {
+          render: `Erro ao confirmar matrícula: ${(error as Error).message}`,
+          type: "error",
+          isLoading: false,
+          autoClose: 5000,
+          closeOnClick: true,
+        });
+      }
+    }
   };
 
   const handleSendEmailDeclaredInterest = async (studentId: string) => {

--- a/src/services/prepCourse/student/confirmEnrolled.ts
+++ b/src/services/prepCourse/student/confirmEnrolled.ts
@@ -12,8 +12,9 @@ export async function confirmEnrolled(studentId: string, classId: string, token:
     }
   );
   if (response.status === 400) {
-    const res = await response.json();
-    throw new Error(res.message);
+    const err = new Error("Processo Seletivo de Teste: Não é possível matricular estudantes");
+    (err as Error & { isTestPS: boolean }).isTestPS = true;
+    throw err;
   }
   if (response.status === 500) {
     throw new Error(`Ops, ocorreu um problema na requisição. Tente novamente!`);


### PR DESCRIPTION
## Summary
- **Modal de confirmação de PS de Teste**: título alterado para **"Atenção"** em fonte grande e amarela; texto expandido com lista explicitando que (1) não é possível converter para PS normal após criação e (2) nenhum estudante pode ser matriculado
- **Checkbox de confirmação**: botão Salvar fica desativado até o usuário marcar "Entendi e quero continuar"; estado resetado ao abrir e ao cancelar o modal
- **Toast de matrícula bloqueada**: substituído o toast de erro genérico por **toast dark info** com a mensagem fixa "Processo Seletivo de Teste: Não é possível matricular estudantes"; erros de rede/500 continuam exibindo toast de erro normal
- **Modal de criação de PS**: botão de submit renomeado de "Salvar" para **"Criar"** (modo edição permanece "Salvar")

## Test Plan
- [ ] Criar um PS marcando "teste" → modal abre com título "Atenção" em destaque e lista com as duas restrições
- [ ] Botão Salvar desativado até marcar o checkbox "Entendi e quero continuar"
- [ ] Cancelar o modal e reabrir → checkbox desmarcado
- [ ] Tentar matricular estudante em PS de teste → toast escuro com "Processo Seletivo de Teste: Não é possível matricular estudantes"
- [ ] Erro de rede/500 em matrícula → toast de erro normal
- [ ] Criar novo PS (sem ser teste) → botão exibe "Criar"; editar PS existente → botão exibe "Salvar"
- [ ] `npx tsc --noEmit` sem erros