### PR TITLE
feat(map): título dinâmico e pin por tipo no Localiza Cursinho

### DIFF
--- a/src/components/organisms/mapBoxInfo/mapBoxInfoGeo.tsx
+++ b/src/components/organisms/mapBoxInfo/mapBoxInfoGeo.tsx
@@ -14,17 +14,26 @@ import {
 } from "react-icons/fa";
 import { MdOutlineTravelExplore } from "react-icons/md";
 import BLink from "../../molecules/bLink";
+import { TypeMarker } from "../../../types/map/marker";
+import { MarkerPin } from "../../molecules/mapBox";
 
 interface MapBoxInfoProps {
   geo?: Geolocation;
   ctaLink: string;
+  label?: string;
+  markerType?: TypeMarker;
 }
 
-function MapBoxInfoGeo({ geo, ctaLink }: MapBoxInfoProps) {
+function MapBoxInfoGeo({ geo, ctaLink, label, markerType }: MapBoxInfoProps) {
   return (
     <>
-      <Text className="flex items-center justify-center">
-        <FaMapMarkerAlt color="red" size={30} /> Localiza Cursinho
+      <Text className="flex items-center justify-center gap-2">
+        {markerType != null ? (
+          <MarkerPin type={markerType} size={30} />
+        ) : (
+          <FaMapMarkerAlt color="red" size={30} />
+        )}
+        {label ?? "Localiza Cursinho"}
       </Text>
       <Text size="quaternary" className="m-0">
         {geo?.name}

--- a/src/pages/homeV2/sections/MapSection/MapInfoCard.tsx
+++ b/src/pages/homeV2/sections/MapSection/MapInfoCard.tsx
@@ -22,6 +22,9 @@ interface Props {
 
 export function MapInfoCard({ activeMarker, boxRef, onReport, onClose }: Props) {
   if (!activeMarker) return null;
+
+  const label = activeMarker.type === TypeMarker.geo ? "Cursinho" : "Universidade";
+
   return (
     <motion.div
       ref={boxRef}
@@ -29,8 +32,8 @@ export function MapInfoCard({ activeMarker, boxRef, onReport, onClose }: Props) 
       animate={{ opacity: 1, y: 0 }}
       className="
         absolute z-30
-        inset-x-3 bottom-3 max-h-[60vh]
-        md:left-auto md:inset-auto md:bottom-6 md:right-6 md:w-[420px] md:max-h-[70vh]
+        left-3 right-3 bottom-3 max-h-[60vh]
+        md:left-auto md:top-auto md:right-6 md:bottom-6 md:w-[420px] md:max-h-[70vh]
         bg-white/90 backdrop-blur-xl backdrop-saturate-150 border border-white/40
         rounded-2xl shadow-xl text-marine overflow-y-auto
       "
@@ -54,7 +57,7 @@ export function MapInfoCard({ activeMarker, boxRef, onReport, onClose }: Props) 
         </button>
       </div>
       <div className="p-5 pt-12">
-        <MapBoxInfoGeo geo={activeMarker.infos} ctaLink={FORM_GEOLOCATION} />
+        <MapBoxInfoGeo geo={activeMarker.infos} ctaLink={FORM_GEOLOCATION} label={label} markerType={activeMarker.type} />
       </div>
     </motion.div>
   );

--- a/src/pages/homeV2/sections/MapSection/index.tsx
+++ b/src/pages/homeV2/sections/MapSection/index.tsx
@@ -83,6 +83,15 @@ export const MapSection: SectionComponent<null> = () => {
         handleClickMarker={handleClickMarker}
       />
       <MapFilterCard filterMarkers={filterMarkers} onToggle={handleFilterMarkers} />
+      <div
+        className="
+          absolute z-30 bottom-3 left-3 md:bottom-6 md:left-6
+          bg-white/90 backdrop-blur-xl backdrop-saturate-150 border border-white/40
+          rounded-2xl shadow-xl px-4 py-3
+        "
+      >
+        <p className="text-marine font-bold text-2xl m-0">Localiza Cursinho</p>
+      </div>
       <MapInfoCard
         activeMarker={activeMarker}
         boxRef={boxRef as RefObject<HTMLDivElement>}


### PR DESCRIPTION
## Summary

- Título do card de informação muda dinamicamente para **Cursinho** ou **Universidade** conforme o tipo do pin clicado
- Pin no card usa o mesmo componente `MarkerPin` do filtro (ícone + cor por tipo: azul/BookOpen para cursinho, vermelho/Landmark para universidade)
- Label **Localiza Cursinho** fixo no canto inferior esquerdo do mapa com estilo glassmorphism (`bg-white/90 backdrop-blur-xl`) em `text-2xl`
- Corrigido posicionamento do card em desktop: removido `md:inset-auto` que sobrescrevia `md:bottom-6`, card agora fica corretamente no canto inferior direito
- Título "Cursinho"/"Universidade" em `text-4xl` (padrão do componente `Text`)

## Test plan

- [ ] Clicar em um pin de cursinho → card exibe título "Cursinho" com pin azul/BookOpen
- [ ] Clicar em um pin de universidade → card exibe título "Universidade" com pin vermelho/Landmark
- [ ] Em desktop (≥768px): card aparece no canto inferior direito
- [ ] Label "Localiza Cursinho" visível no canto inferior esquerdo em mobile e desktop
- [ ] Home legado (`/home-legacy`) não foi afetado (fallback para `FaMapMarkerAlt` quando `markerType` não é passado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)