### PR TITLE
feat(dashHome): flag ativo/inativo para apoiadores

### DIFF
--- a/src/dtos/homeContent/homeSupporter.ts
+++ b/src/dtos/homeContent/homeSupporter.ts
@@ -4,6 +4,7 @@ export interface HomeSupporter {
   logoUrl: string | null;
   link: string;
   description?: string | null;
+  active: boolean;
   order: number;
   createdAt: string;
   updatedAt: string;

--- a/src/pages/dashHome/components/SortableSupporterRow.tsx
+++ b/src/pages/dashHome/components/SortableSupporterRow.tsx
@@ -7,10 +7,12 @@ export default function SortableSupporterRow({
   supporter,
   onEdit,
   onDelete,
+  onToggleActive,
 }: {
   supporter: HomeSupporter;
   onEdit: (s: HomeSupporter) => void;
   onDelete: (s: HomeSupporter) => void;
+  onToggleActive: (s: HomeSupporter) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: supporter.id });
@@ -25,7 +27,7 @@ export default function SortableSupporterRow({
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-3 p-3 border rounded bg-white"
+      className={`flex items-center gap-3 p-3 border rounded bg-white${!supporter.active ? " opacity-50" : ""}`}
     >
       <button
         type="button"
@@ -46,7 +48,14 @@ export default function SortableSupporterRow({
         <div className="w-12 h-12 rounded bg-gray-200" />
       )}
       <div className="flex-1 min-w-0 flex flex-col">
-        <span className="font-medium truncate">{supporter.name}</span>
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">{supporter.name}</span>
+          {!supporter.active && (
+            <span className="text-xs bg-gray-200 text-gray-600 px-1.5 py-0.5 rounded">
+              inativo
+            </span>
+          )}
+        </div>
         <a
           href={supporter.link}
           target="_blank"
@@ -63,6 +72,13 @@ export default function SortableSupporterRow({
         onClick={() => onEdit(supporter)}
       >
         Editar
+      </button>
+      <button
+        type="button"
+        className={`text-sm hover:underline ${supporter.active ? "text-yellow-600" : "text-green-600"}`}
+        onClick={() => onToggleActive(supporter)}
+      >
+        {supporter.active ? "Inativar" : "Ativar"}
       </button>
       <button
         type="button"

--- a/src/pages/dashHome/sections/SupportersSection.tsx
+++ b/src/pages/dashHome/sections/SupportersSection.tsx
@@ -18,9 +18,10 @@ import {
 import Button from "@/components/molecules/button";
 import { useAuthStore } from "../../../store/auth";
 import { HomeSupporter } from "../../../dtos/homeContent/homeSupporter";
-import { getHomeSupporters } from "../../../services/home/getHomeSupporters";
+import { getAdminHomeSupporters } from "../../../services/home/getAdminHomeSupporters";
 import { deleteHomeSupporter } from "../../../services/home/deleteHomeSupporter";
 import { reorderHomeSupporters } from "../../../services/home/reorderHomeSupporters";
+import { updateHomeSupporter } from "../../../services/home/updateHomeSupporter";
 import SortableSupporterRow from "../components/SortableSupporterRow";
 import ModalEditSupporter from "../modals/ModalEditSupporter";
 
@@ -39,11 +40,11 @@ export default function SupportersSection() {
   );
 
   useEffect(() => {
-    getHomeSupporters()
+    getAdminHomeSupporters(token)
       .then((list) => setSupporters(list))
       .catch((e: Error) => toast.error(e.message))
       .finally(() => setLoading(false));
-  }, []);
+  }, [token]);
 
   const onDragEnd = async (e: DragEndEvent) => {
     const { active, over } = e;
@@ -61,6 +62,18 @@ export default function SupportersSection() {
       );
     } catch (err) {
       setSupporters(previous);
+      toast.error((err as Error).message);
+    }
+  };
+
+  const onToggleActive = async (s: HomeSupporter) => {
+    const action = s.active ? "inativar" : "ativar";
+    if (!window.confirm(`Deseja ${action} "${s.name}"?`)) return;
+    try {
+      const updated = await updateHomeSupporter(s.id, { active: !s.active }, token);
+      setSupporters((prev) => prev.map((x) => (x.id === updated.id ? updated : x)));
+      toast.success(`Apoiador ${s.active ? "inativado" : "ativado"}`);
+    } catch (err) {
       toast.error((err as Error).message);
     }
   };
@@ -103,7 +116,9 @@ export default function SupportersSection() {
       <h2 className="text-xl font-semibold">Apoiadores</h2>
       <div className="flex justify-between items-center">
         <span className="text-sm text-gray-600">
-          {supporters.length} apoiador(es)
+          {supporters.filter((s) => s.active).length} ativo(s)
+          {supporters.some((s) => !s.active) &&
+            ` · ${supporters.filter((s) => !s.active).length} inativo(s)`}
         </span>
         <Button typeStyle="primary" size="small" onClick={openCreate}>
           Adicionar apoiador
@@ -125,6 +140,7 @@ export default function SupportersSection() {
                 supporter={s}
                 onEdit={openEdit}
                 onDelete={onDelete}
+                onToggleActive={onToggleActive}
               />
             ))}
           </div>

--- a/src/services/home/getAdminHomeSupporters.ts
+++ b/src/services/home/getAdminHomeSupporters.ts
@@ -1,0 +1,15 @@
+import { HomeSupporter } from "../../dtos/homeContent/homeSupporter";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { homeSupportersAll } from "../urls";
+
+export async function getAdminHomeSupporters(
+  token: string,
+): Promise<HomeSupporter[]> {
+  const res = await fetchWrapper(homeSupportersAll, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status !== 200) throw new Error("Erro ao buscar Apoiadores");
+  const text = await res.text();
+  return text ? (JSON.parse(text) as HomeSupporter[]) : [];
+}

--- a/src/services/home/updateHomeSupporter.ts
+++ b/src/services/home/updateHomeSupporter.ts
@@ -4,7 +4,7 @@ import { homeSupporters } from "../urls";
 
 export async function updateHomeSupporter(
   id: number,
-  payload: { name?: string; link?: string; description?: string | null },
+  payload: { name?: string; link?: string; description?: string | null; active?: boolean },
   token: string,
 ): Promise<HomeSupporter> {
   const res = await fetchWrapper(`${homeSupporters}/${id}`, {

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -160,6 +160,7 @@ export const homeFeatures = `${homeContent}/features`;
 export const homeFeaturesReorder = `${homeFeatures}/reorder`;
 export const homeFeatureImage = (id: number) => `${homeFeatures}/${id}/image`;
 export const homeSupporters = `${homeContent}/supporters`;
+export const homeSupportersAll = `${homeSupporters}/all`;
 export const homeSupportersReorder = `${homeSupporters}/reorder`;
 export const homeSupporterLogo = (id: number) => `${homeSupporters}/${id}/logo`;
 export const homeContentFile = (fileKey: string) =>


### PR DESCRIPTION
## Summary
- Interface `HomeSupporter` inclui campo `active: boolean`
- `SupportersSection` usa novo endpoint admin (`/supporters/all`) para exibir ativos e inativos
- Contagem no header mostra "X ativo(s) · Y inativo(s)"
- `SortableSupporterRow`: badge cinza "inativo", opacidade 50% e botão "Ativar" / "Inativar"
- Home pública não muda — API já filtra só ativos no endpoint público

## Test plan
- [ ] DashHome lista todos os apoiadores (ativos e inativos)
- [ ] Apoiadores inativos aparecem com badge "inativo" e opacidade reduzida
- [ ] Botão "Inativar" desativa o apoiador e atualiza a lista imediatamente
- [ ] Botão "Ativar" reativa o apoiador
- [ ] Home pública (`/`) não exibe apoiadores inativos
- [ ] Requer PR api-vcnafacul `feature/supporter-active-flag` mergeado antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)