### PR TITLE
fix(questao): corrige modal de edição quebrando com número null

### DIFF
--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
@@ -86,17 +86,18 @@ export function TabClassificacao({
         setLoadingNumeros(true);
         try {
           const numeros = await getMissingNumber(provaId, token);
-          // Incluir o número atual da questão na lista de disponíveis
-          const numerosComAtual = [...numeros, question.numero].sort(
-            (a, b) => a - b
-          );
+          // Incluir o número atual da questão na lista de disponíveis (ignorar se for null)
+          const numerosComAtual = [
+            ...numeros,
+            ...(question.numero != null ? [question.numero] : []),
+          ].sort((a, b) => a - b);
           // Remover duplicatas
           const numerosUnicos = Array.from(new Set(numerosComAtual));
           setNumerosDisponiveis(numerosUnicos);
         } catch (error) {
           console.error("Erro ao buscar números disponíveis:", error);
-          // Em caso de erro, usar apenas o número atual
-          setNumerosDisponiveis([question.numero]);
+          // Em caso de erro, usar apenas o número atual (se existir)
+          setNumerosDisponiveis(question.numero != null ? [question.numero] : []);
         } finally {
           setLoadingNumeros(false);
         }


### PR DESCRIPTION
## Summary
- Corrige crash ao abrir o modal de edição de questões cujo campo `numero` é `null`
- O bug ocorria porque `null` era incluído no array de números disponíveis, causando `null.toString()` no `SelectItem` e resultados inválidos no sort numérico
- Fix: filtra `question.numero` com `!= null` antes de adicioná-lo à lista de disponíveis, tanto no caminho principal quanto no fallback de erro

## Test plan
- [ ] Abrir modal de edição de uma questão com `numero = null` — não deve quebrar
- [ ] Clicar em "Editar Classificação" — select de número deve mostrar apenas números disponíveis da API
- [ ] Editar e salvar questão com `numero = null` — deve salvar sem erro
- [ ] Editar questão com número válido — comportamento anterior mantido (número atual incluído na lista de disponíveis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)