### PR TITLE
fix(question-modal): abas sempre em linha horizontal única

### DIFF
--- a/src/pages/dashQuestionNew/components/ModalTabTemplateQuestion.tsx
+++ b/src/pages/dashQuestionNew/components/ModalTabTemplateQuestion.tsx
@@ -21,14 +21,6 @@ function ModalTabTemplateQuestion({
   className,
   footerContent,
 }: ModalTabTemplateQuestionProps) {
-  // Define o número de colunas baseado no número de tabs
-  const gridCols =
-    tabs.length <= 2
-      ? "grid-cols-2"
-      : tabs.length === 3
-      ? "grid-cols-3"
-      : "grid-cols-4";
-
   if (!isOpen) return null;
 
   // Garante que sempre há um defaultValue válido
@@ -43,9 +35,22 @@ function ModalTabTemplateQuestion({
           defaultValue={defaultTabId}
           className="w-full max-w-6xl"
         >
-          <TabsList className={`grid w-full ${gridCols}`}>
+          {/* Colunas geradas dinamicamente: sempre 1 coluna por aba, todas
+              com a mesma largura (minmax(0,1fr) permite encolher). Assim as
+              abas ficam sempre em uma única linha horizontal, diminuindo de
+              tamanho conforme mais abas são adicionadas. */}
+          <TabsList
+            className="grid w-full"
+            style={{
+              gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
+            }}
+          >
             {tabs.map((tab) => (
-              <TabsTrigger key={tab.id} value={tab.id}>
+              <TabsTrigger
+                key={tab.id}
+                value={tab.id}
+                className="min-w-0 px-2 overflow-hidden text-ellipsis"
+              >
                 {tab.label}
               </TabsTrigger>
             ))}


### PR DESCRIPTION
Closes #637

## Problema

No modal de edição de questão existem 5 abas (Classificação, Enunciado, Alternativas, Imagens, Histórico), mas o template limitava o grid a **4 colunas** (`grid-cols-4`). A 5ª aba quebrava para uma segunda linha e ficava escondida por falta de espaço vertical.

## Correção

Em `ModalTabTemplateQuestion.tsx`:

- Removida a lógica que travava o grid em 4 colunas.
- Colunas agora geradas dinamicamente: `gridTemplateColumns: repeat(${tabs.length}, minmax(0, 1fr))` — **1 coluna por aba, sempre em uma única linha horizontal**.
- Abas usam `min-w-0` + `overflow-hidden text-ellipsis`, então encolhem uniformemente conforme mais abas são adicionadas, sem crescer na vertical.

Totalmente genérico: 3 abas → 3 colunas, 5 → 5, 7 → 7, sempre em linha só.

## Teste

- [x] Typecheck (`tsc --noEmit`) sem erros no arquivo alterado
- [ ] Verificar visualmente as 5 abas em uma linha no modal de questão

🤖 Generated with [Claude Code](https://claude.com/claude-code)
