### PR TITLE
fix(questao): mostrar quais campos/abas bloqueiam o save no modal de edição

### DIFF
--- a/src/pages/dashQuestionNew/modals/tabs/TabConteudo/index.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabConteudo/index.tsx
@@ -5,12 +5,41 @@ import { RichTextRenderer } from "@/components/atoms/richTextRenderer/RichTextRe
 import { AlertCircle, Edit, Loader2, Save, X } from "lucide-react";
 import { PendingImageStore } from "@/utils/pendingImageStore";
 import { lazy, Suspense } from "react";
-import { Controller, UseFormReturn } from "react-hook-form";
+import { Controller, FieldErrors, UseFormReturn } from "react-hook-form";
 import { ConteudoFormData } from "./schema";
 
 const RichTextEditor = lazy(
   () => import("@/components/molecules/richTextEditor/RichTextEditor")
 );
+
+/**
+ * Metadados de cada campo do form: rótulo amigável e em qual aba do modal ele
+ * fica. Usado para mostrar, na barra de ações (aba Enunciado, onde vive o botão
+ * Salvar), exatamente quais campos bloqueiam o save e onde corrigi-los —
+ * inclusive quando o campo inválido está em outra aba (ex.: alternativas vazias
+ * em questões legadas com alternativas em imagem).
+ */
+const FIELD_META: Record<string, { label: string; tab: string }> = {
+  textoQuestao: { label: "Texto da questão", tab: "Enunciado" },
+  pergunta: { label: "Pergunta", tab: "Enunciado" },
+  textoAlternativaA: { label: "Alternativa A", tab: "Alternativas" },
+  textoAlternativaB: { label: "Alternativa B", tab: "Alternativas" },
+  textoAlternativaC: { label: "Alternativa C", tab: "Alternativas" },
+  textoAlternativaD: { label: "Alternativa D", tab: "Alternativas" },
+  textoAlternativaE: { label: "Alternativa E", tab: "Alternativas" },
+  alternativa: { label: "Alternativa correta", tab: "Alternativas" },
+};
+
+function collectFieldErrors(errors: FieldErrors<ConteudoFormData>) {
+  return Object.entries(errors)
+    .filter(([, err]) => err?.message)
+    .map(([field, err]) => ({
+      field,
+      label: FIELD_META[field]?.label ?? field,
+      tab: FIELD_META[field]?.tab,
+      message: String((err as { message?: unknown })?.message ?? "inválido"),
+    }));
+}
 
 interface TabConteudoProps {
   form: UseFormReturn<ConteudoFormData>;
@@ -224,9 +253,23 @@ export function TabConteudo({
                   </p>
                 )}
                 {!isValid && isDirty && (
-                  <p className="text-sm text-red-600 mt-1">
-                    Por favor, corrija os erros antes de salvar
-                  </p>
+                  <div className="mt-1 space-y-1">
+                    <p className="text-sm text-red-600 font-medium flex items-center gap-1">
+                      <AlertCircle className="h-4 w-4" />
+                      Corrija os campos abaixo antes de salvar:
+                    </p>
+                    <ul className="text-sm text-red-600 list-disc list-inside space-y-0.5">
+                      {collectFieldErrors(errors).map((e) => (
+                        <li key={e.field}>
+                          <span className="font-medium">{e.label}</span>
+                          {e.tab && (
+                            <span className="text-red-500"> (aba {e.tab})</span>
+                          )}
+                          : {e.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
               </div>
 


### PR DESCRIPTION
Closes #638

## Problema (draft "Erro oculto ao alterar questões com imagem no texto")

Ao editar certas questões (ex.: `_id 67f2a1ce28db02438df9769d`) — tipicamente **legadas do ENEM cujas alternativas/enunciado são imagens** — mexer em qualquer coisa (inclusive o checkbox de "Revisões Necessárias") mostrava *"Por favor, corrija os erros antes de salvar"* com o botão Salvar desabilitado, sem indicar o que corrigir.

## Causa raiz (confirmada com dado real)

Inspeção read-only no Mongo de dev mostrou que essas questões têm as **5 `textoAlternativa{A-E}` vazias** (o conteúdo das alternativas está na imagem, não em texto). O `conteudoSchema` (Yup) exige cada alternativa não-vazia (`.min(1)`), então:

1. `isValid = false`
2. botão **Salvar** fica `disabled`
3. aparece a mensagem genérica de erro
4. **mas os campos inválidos estão na aba _Alternativas_** — ao editar a aba _Enunciado_ (onde vive o Salvar), o usuário não via qual campo/aba corrigir

A "imagem no texto" que o ticket notou era **correlação**, não causa: questões com imagem tendem a ter alternativas em imagem (texto vazio). Também descartei o limite de 20000 chars (maior `textoQuestao` real = 2695).

## Correção (decisão de produto: **não relaxar** a validação, só torná-la visível)

A barra de ações passa a listar cada campo inválido com seu **rótulo e a aba** onde corrigi-lo — ex.: *"Alternativa A (aba Alternativas): A alternativa A não pode estar vazia"*. O bloqueio deixa de ser oculto e vira acionável (o revisor sabe que precisa preencher as alternativas a partir da imagem).

### Escopo consciente
Isto **não** desbloqueia por si só o toggle de Revisões nessas questões legadas — enquanto as alternativas estiverem vazias, o Salvar segue desabilitado (por escolha, para não afrouxar a validação de conteúdo). Passa a ser possível ver e corrigir o motivo.

## Verificação
- `tsc --noEmit`: sem erros no arquivo alterado.
- ESLint (config do projeto): `TabConteudo/index.tsx` limpo.
- Lógica `collectFieldErrors` validada com o cenário real (5 alternativas vazias → 5 itens, todos "aba Alternativas").
- Falta verificação visual no navegador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
