### PR TITLE
feat(categoria): CRUD Categoria frontend — services + modal ManageCategorias (Cards 04+05)

### DIFF
--- a/src/pages/dashProvas/index.tsx
+++ b/src/pages/dashProvas/index.tsx
@@ -22,6 +22,7 @@ import { Paginate } from "../../utils/paginate";
 import { dashProva } from "./data";
 import NewProva from "./modals/newProva";
 import ShowProva from "./modals/showProva";
+import ManageCategorias from "./modals/manageCategorias";
 import { downloadSyncReportPdf } from "./utils/syncReportPdf";
 import { useModals } from "@/hooks/useModal";
 
@@ -48,6 +49,7 @@ function DashProva() {
   const modals = useModals([
     'modalNewProva',
     'modalShowProva',
+    'modalManageCategorias',
   ]);
 
   const {
@@ -99,6 +101,16 @@ function DashProva() {
         addProva={addProva}
         handleClose={() => modals.modalNewProva.close()}
         isOpen={modals.modalNewProva.isOpen}
+      />
+    );
+  };
+
+  const ModalManageCategorias = () => {
+    return !modals.modalManageCategorias.isOpen ? null : (
+      <ManageCategorias
+        isOpen={modals.modalManageCategorias.isOpen}
+        handleClose={() => modals.modalManageCategorias.close()}
+        onCategoriasChanged={(cats) => setCategorias(cats)}
       />
     );
   };
@@ -292,6 +304,13 @@ function DashProva() {
       children: "Nova Prova",
     },
     {
+      disabled: !permissao[Roles.alterarPermissao],
+      onClick: () => modals.modalManageCategorias.open(),
+      typeStyle: "tertiary",
+      size: "small",
+      children: "Gerenciar Categorias",
+    },
+    {
       disabled: !hasActiveFilters,
       onClick: clearFilters,
       typeStyle: "refused",
@@ -331,6 +350,7 @@ function DashProva() {
       <DashCardTemplate key={resetKey} customFilter={[GabaritoCheckbox]} />
       <ModalNewProva />
       <ModalShowProva />
+      <ModalManageCategorias />
     </DashCardContext.Provider>
   );
 }

--- a/src/pages/dashProvas/index.tsx
+++ b/src/pages/dashProvas/index.tsx
@@ -306,7 +306,7 @@ function DashProva() {
     {
       disabled: !permissao[Roles.alterarPermissao],
       onClick: () => modals.modalManageCategorias.open(),
-      typeStyle: "tertiary",
+      typeStyle: "secondary",
       size: "small",
       children: "Gerenciar Categorias",
     },

--- a/src/pages/dashProvas/modals/manageCategorias/createForm.tsx
+++ b/src/pages/dashProvas/modals/manageCategorias/createForm.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from "react";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import Button from "../../../../components/molecules/button";
+import { ICategoria } from "../../../../dtos/categoria/categoria";
+import { useToastAsync } from "../../../../hooks/useToastAsync";
+import {
+  createCategoria,
+  CreateCategoriaInput,
+} from "../../../../services/categoria/createCategoria";
+import { gerarNomePreview } from "./nomePreview";
+
+export interface ExameOption {
+  value: string;
+  label: string;
+}
+
+interface CreateFormProps {
+  exameOptions: ExameOption[];
+  token: string;
+  onCreated: (categoria: ICategoria) => void;
+  onCancel: () => void;
+}
+
+function CreateForm({
+  exameOptions,
+  token,
+  onCreated,
+  onCancel,
+}: CreateFormProps) {
+  const execute = useToastAsync();
+
+  const [exame, setExame] = useState("");
+  const [duracao, setDuracao] = useState<number | "">("");
+  const [semAlvo, setSemAlvo] = useState(false);
+  const [quantidade, setQuantidade] = useState<number | "">("");
+  const [prefixo, setPrefixo] = useState("");
+  const [salvando, setSalvando] = useState(false);
+
+  const quantidadeAplicada: number | null = semAlvo
+    ? null
+    : quantidade === ""
+      ? null
+      : quantidade;
+
+  const preview = useMemo(
+    () =>
+      gerarNomePreview(
+        prefixo,
+        quantidadeAplicada,
+        duracao === "" ? null : duracao,
+      ),
+    [prefixo, quantidadeAplicada, duracao],
+  );
+
+  const valido = exame !== "" && duracao !== "" && Number(duracao) > 0;
+
+  const handleSalvar = async () => {
+    if (!valido) return;
+    const input: CreateCategoriaInput = {
+      exame,
+      duracao: Number(duracao),
+      quantidadeTotalQuestao: quantidadeAplicada,
+    };
+    if (prefixo.trim()) {
+      input.prefixo = prefixo.trim();
+    }
+
+    setSalvando(true);
+    await execute({
+      action: () => createCategoria(input, token),
+      loadingMessage: "Criando categoria...",
+      successMessage: "Categoria criada",
+      errorMessage: (err: Error) => err.message,
+      onSuccess: (categoria) => onCreated(categoria),
+      onFinally: () => setSalvando(false),
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeftIcon className="h-4 w-4" /> Voltar
+        </button>
+        <h2 className="text-xl font-semibold text-gray-900">
+          Nova Categoria personalizada
+        </h2>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          Exame *
+          <select
+            value={exame}
+            onChange={(e) => setExame(e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          >
+            <option value="">Selecione um exame</option>
+            {exameOptions.map((op) => (
+              <option key={op.value} value={op.value}>
+                {op.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          Duração (min) *
+          <input
+            type="number"
+            min={1}
+            value={duracao}
+            onChange={(e) =>
+              setDuracao(e.target.value === "" ? "" : Number(e.target.value))
+            }
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          />
+        </label>
+
+        <div className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          Qtd de questões
+          <div className="flex items-center gap-3">
+            <input
+              type="number"
+              min={1}
+              value={semAlvo ? "" : quantidade}
+              disabled={semAlvo}
+              onChange={(e) =>
+                setQuantidade(
+                  e.target.value === "" ? "" : Number(e.target.value),
+                )
+              }
+              className="w-32 rounded-md border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100"
+            />
+            <label className="flex cursor-pointer items-center gap-2 font-normal">
+              <input
+                type="checkbox"
+                checked={semAlvo}
+                onChange={(e) => setSemAlvo(e.target.checked)}
+                className="h-4 w-4 accent-marine"
+              />
+              sem alvo / livre
+            </label>
+          </div>
+        </div>
+
+        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          Prefixo (opcional)
+          <input
+            type="text"
+            value={prefixo}
+            placeholder="Personalizado"
+            onChange={(e) => setPrefixo(e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          />
+        </label>
+
+        <div className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-600">
+          Preview do nome:{" "}
+          <span className="font-semibold text-gray-900">{preview}</span>
+        </div>
+      </div>
+
+      <div className="mt-6 flex justify-end gap-3">
+        <Button typeStyle="refused" size="small" onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button
+          typeStyle="primary"
+          size="small"
+          disabled={!valido || salvando}
+          onClick={handleSalvar}
+        >
+          Salvar
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default CreateForm;

--- a/src/pages/dashProvas/modals/manageCategorias/deleteConfirm.tsx
+++ b/src/pages/dashProvas/modals/manageCategorias/deleteConfirm.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import Button from "../../../../components/molecules/button";
+import { ICategoria } from "../../../../dtos/categoria/categoria";
+import { useToastAsync } from "../../../../hooks/useToastAsync";
+import { deleteCategoria } from "../../../../services/categoria/deleteCategoria";
+
+interface DeleteConfirmProps {
+  categoria: ICategoria;
+  token: string;
+  onDeleted: (id: string) => void;
+  onCancel: () => void;
+}
+
+function DeleteConfirm({
+  categoria,
+  token,
+  onDeleted,
+  onCancel,
+}: DeleteConfirmProps) {
+  const execute = useToastAsync();
+  const [excluindo, setExcluindo] = useState(false);
+
+  const handleExcluir = async () => {
+    setExcluindo(true);
+    await execute({
+      action: () => deleteCategoria(categoria._id, token),
+      loadingMessage: "Excluindo categoria...",
+      successMessage: "Categoria excluída",
+      // A service já monta a mensagem do 409 com a contagem de simulados.
+      errorMessage: (err: Error) => err.message,
+      onSuccess: () => onDeleted(categoria._id),
+      onError: () => onCancel(),
+      onFinally: () => setExcluindo(false),
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="mb-4 text-xl font-semibold text-gray-900">
+        Excluir Categoria
+      </h2>
+      <p className="text-sm text-gray-700">
+        Excluir a categoria{" "}
+        <span className="font-semibold">&quot;{categoria.nome}&quot;</span>?
+      </p>
+      <p className="mt-1 text-sm text-gray-500">
+        Esta ação não pode ser desfeita.
+      </p>
+
+      <div className="mt-6 flex justify-end gap-3">
+        <Button typeStyle="refused" size="small" onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button
+          typeStyle="primary"
+          size="small"
+          disabled={excluindo}
+          onClick={handleExcluir}
+        >
+          Excluir
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default DeleteConfirm;

--- a/src/pages/dashProvas/modals/manageCategorias/index.tsx
+++ b/src/pages/dashProvas/modals/manageCategorias/index.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import { Cog6ToothIcon, TrashIcon } from "@heroicons/react/24/outline";
+import Button from "../../../../components/molecules/button";
+import ModalTemplate from "../../../../components/templates/modalTemplate";
+import { ICategoria } from "../../../../dtos/categoria/categoria";
+import { getCategorias } from "../../../../services/categoria/getCategorias";
+import { useAuthStore } from "../../../../store/auth";
+import CreateForm, { ExameOption } from "./createForm";
+import DeleteConfirm from "./deleteConfirm";
+import { isProtegida } from "./protectedTipos";
+
+interface ManageCategoriasProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  onCategoriasChanged: (categorias: ICategoria[]) => void;
+}
+
+type View = "lista" | "criar" | "excluir";
+
+function ManageCategorias({
+  isOpen,
+  handleClose,
+  onCategoriasChanged,
+}: ManageCategoriasProps) {
+  const {
+    data: { token },
+  } = useAuthStore();
+
+  const [view, setView] = useState<View>("lista");
+  const [categorias, setCategorias] = useState<ICategoria[]>([]);
+  const [categoriaParaExcluir, setCategoriaParaExcluir] =
+    useState<ICategoria | null>(null);
+  const [busca, setBusca] = useState("");
+
+  useEffect(() => {
+    getCategorias(token)
+      .then((res) => setCategorias(res.data))
+      .catch((erro: Error) => toast.error(erro.message));
+  }, [token]);
+
+  const exameOptions: ExameOption[] = useMemo(() => {
+    const map = new Map<string, string>();
+    categorias.forEach((c) => {
+      if (c.exame && !map.has(c.exame._id)) {
+        map.set(c.exame._id, c.exame.nome);
+      }
+    });
+    return Array.from(map, ([value, label]) => ({ value, label }));
+  }, [categorias]);
+
+  const categoriasFiltradas = useMemo(() => {
+    const termo = busca.trim().toLowerCase();
+    if (!termo) return categorias;
+    return categorias.filter((c) => c.nome.toLowerCase().includes(termo));
+  }, [categorias, busca]);
+
+  const propagar = (novas: ICategoria[]) => {
+    setCategorias(novas);
+    onCategoriasChanged(novas);
+  };
+
+  const handleCreated = (categoria: ICategoria) => {
+    propagar([...categorias, categoria]);
+    setView("lista");
+  };
+
+  const handleDeleted = (id: string) => {
+    propagar(categorias.filter((c) => c._id !== id));
+    setCategoriaParaExcluir(null);
+    setView("lista");
+  };
+
+  const abrirExcluir = (categoria: ICategoria) => {
+    setCategoriaParaExcluir(categoria);
+    setView("excluir");
+  };
+
+  return (
+    <ModalTemplate
+      isOpen={isOpen}
+      handleClose={handleClose}
+      className="w-full max-w-3xl rounded-lg bg-white shadow-xl p-2"
+    >
+      {view === "lista" && (
+        <div className="p-6">
+          <div className="mb-6 flex items-center gap-3">
+            <div className="rounded-lg bg-blue-100 p-2">
+              <Cog6ToothIcon className="h-6 w-6 text-blue-600" />
+            </div>
+            <h2 className="text-xl font-semibold text-gray-900">
+              Gerenciar Categorias
+            </h2>
+          </div>
+
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <Button
+              typeStyle="quaternary"
+              size="small"
+              onClick={() => setView("criar")}
+            >
+              + Nova Categoria
+            </Button>
+            <input
+              type="text"
+              value={busca}
+              placeholder="Buscar por nome"
+              onChange={(e) => setBusca(e.target.value)}
+              className="w-64 rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {categoriasFiltradas.length === 0 && (
+              <p className="py-8 text-center text-sm text-gray-500">
+                Nenhuma categoria encontrada.
+              </p>
+            )}
+            {categoriasFiltradas.map((c) => {
+              const protegida = isProtegida(c.nome);
+              const qtd =
+                c.quantidadeTotalQuestao == null
+                  ? "livre"
+                  : `${c.quantidadeTotalQuestao} questões`;
+              return (
+                <div
+                  key={c._id}
+                  className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 p-4"
+                >
+                  <div className="flex flex-col gap-1">
+                    <span className="font-semibold text-gray-900">
+                      {c.nome}
+                    </span>
+                    <span className="text-sm text-gray-500">
+                      Exame: {c.exame?.nome ?? "—"} · {qtd} · {c.duracao} min ·{" "}
+                      {c.selecionavel ? "Selecionável" : "Uso interno"}
+                    </span>
+                    {protegida && (
+                      <span className="text-xs font-medium text-amber-600">
+                        🔒 Categoria seedada
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={protegida}
+                    title={
+                      protegida
+                        ? "Categoria seedada — não pode ser excluída"
+                        : "Excluir categoria"
+                    }
+                    onClick={() => abrirExcluir(c)}
+                    className="text-gray-400 enabled:hover:text-red disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <TrashIcon className="h-5 w-5" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {view === "criar" && (
+        <CreateForm
+          exameOptions={exameOptions}
+          token={token}
+          onCreated={handleCreated}
+          onCancel={() => setView("lista")}
+        />
+      )}
+
+      {view === "excluir" && categoriaParaExcluir && (
+        <DeleteConfirm
+          categoria={categoriaParaExcluir}
+          token={token}
+          onDeleted={handleDeleted}
+          onCancel={() => {
+            setCategoriaParaExcluir(null);
+            setView("lista");
+          }}
+        />
+      )}
+    </ModalTemplate>
+  );
+}
+
+export default ManageCategorias;

--- a/src/pages/dashProvas/modals/manageCategorias/nomePreview.ts
+++ b/src/pages/dashProvas/modals/manageCategorias/nomePreview.ts
@@ -1,0 +1,14 @@
+/**
+ * Espelha `gerarNomeAuto` do ms-simulado para que o preview no form seja
+ * idêntico ao nome que o backend vai gerar: `<Prefixo> <Nq>|livre <Dmin>`.
+ */
+export function gerarNomePreview(
+  prefixo: string,
+  quantidade: number | null,
+  duracao: number | null,
+): string {
+  const p = prefixo.trim().replace(/\s+/g, " ") || "Personalizado";
+  const parteQtd = quantidade == null ? "livre" : `${quantidade}q`;
+  const dur = duracao ?? 0;
+  return `${p} ${parteQtd} ${dur}min`;
+}

--- a/src/pages/dashProvas/modals/manageCategorias/protectedTipos.ts
+++ b/src/pages/dashProvas/modals/manageCategorias/protectedTipos.ts
@@ -1,0 +1,18 @@
+/**
+ * Nomes das categorias seedadas (imutáveis do ponto de vista de UI).
+ * Usado apenas para exibir o badge "🔒 Categoria seedada" e desabilitar o
+ * botão de excluir no frontend. A regra de verdade (categoria em uso) é
+ * validada pelo backend no momento do DELETE (409 com `simuladosUsando`).
+ */
+export const CATEGORIAS_PROTEGIDAS = [
+  "Enem Dia 1",
+  "Enem Dia 2",
+  "Linguagens",
+  "Ciências Humanas",
+  "Ciências da Natureza",
+  "Matemática",
+];
+
+export function isProtegida(nome: string): boolean {
+  return CATEGORIAS_PROTEGIDAS.includes(nome);
+}

--- a/src/services/categoria/createCategoria.ts
+++ b/src/services/categoria/createCategoria.ts
@@ -1,0 +1,38 @@
+import { ICategoria } from "../../dtos/categoria/categoria";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { categoria } from "../urls";
+
+export interface CreateCategoriaInput {
+  exame: string;
+  duracao: number;
+  quantidadeTotalQuestao: number | null;
+  prefixo?: string;
+  descricao?: string;
+  // nota: nome não é enviado — o backend gera o nome da categoria.
+}
+
+export async function createCategoria(
+  input: CreateCategoriaInput,
+  token: string,
+): Promise<ICategoria> {
+  const response = await fetchWrapper(categoria, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (response.status === 201) {
+    return await response.json();
+  }
+
+  const err = await response.json();
+  if (response.status === 409) {
+    throw new Error(err.message || "Categoria já existe com esse nome");
+  }
+  if (response.status === 400) {
+    throw new Error(err.message || "Dados inválidos");
+  }
+  throw new Error("Erro ao criar categoria");
+}

--- a/src/services/categoria/deleteCategoria.ts
+++ b/src/services/categoria/deleteCategoria.ts
@@ -1,0 +1,28 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { categoriaById } from "../urls";
+
+export async function deleteCategoria(
+  id: string,
+  token: string,
+): Promise<void> {
+  const response = await fetchWrapper(categoriaById(id), {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (response.status === 200 || response.status === 204) {
+    return;
+  }
+
+  if (response.status === 409) {
+    const err = await response.json();
+    const detalhes =
+      err.simuladosUsando != null
+        ? `${err.simuladosUsando} simulados usam essa categoria`
+        : err.message;
+    throw new Error(`Categoria em uso — ${detalhes}`);
+  }
+  throw new Error("Erro ao excluir categoria");
+}

--- a/src/services/categoria/getCategoriaById.ts
+++ b/src/services/categoria/getCategoriaById.ts
@@ -1,0 +1,20 @@
+import { ICategoria } from "../../dtos/categoria/categoria";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { categoriaById } from "../urls";
+
+export async function getCategoriaById(
+  id: string,
+  token: string,
+): Promise<ICategoria> {
+  const response = await fetchWrapper(categoriaById(id), {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (response.status !== 200) {
+    throw new Error(`Erro ao buscar categoria ${id}`);
+  }
+  return await response.json();
+}

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -49,6 +49,7 @@ export const mssimulado = `${BASE_URL}/mssimulado`;
 
 export const simulado = `${mssimulado}/simulado`;
 export const categoria = `${mssimulado}/categoria`;
+export const categoriaById = (id: string) => `${categoria}/${id}`;
 export const toAnswer = `${simulado}/toanswer`;
 export const answer = `${simulado}/answer`;
 export const report = `${simulado}/report`;


### PR DESCRIPTION
## Resumo

Frontend da **Etapa 3 (CRUD Categoria)** no client-vcnafacul. PR encadeado que entrega os **Cards 04 e 05** juntos (o Card 04 não abriu PR próprio por design).

### Card 04 — Services (`7f64aae`)
- `urls.ts`: helper `categoriaById(id)`
- `getCategoriaById.ts` — GET por id
- `createCategoria.ts` — POST (não envia `nome`; backend gera), trata 201/409/400
- `deleteCategoria.ts` — DELETE, trata 200/204 e extrai `simuladosUsando` do 409

### Card 05 — Modal `ManageCategorias` + integração `DashProva` (`52fb87f`)
- Modal com 3 vistas: **lista** (busca + badge de seedada), **criar** (form com preview do nome em tempo real), **excluir** (confirmação + tratamento de 409)
- Botão "Gerenciar Categorias" na `DashProva`, gated por `alterarPermissao`
- Sync com a `DashProva` via `onCategoriasChanged` → categoria nova/excluída reflete no select do `NewProva`

## Correções aplicadas vs. spec do card
- **Slot `modalManageCategorias` não existia** na `DashProva` (a spec dizia que ficou pronto na etapa 2) — adicionado por completo.
- **`getExames` não existe** — as opções de exame são derivadas da própria lista de categorias (`.exame`, dedupe por `_id`), sem service novo.
- **`ICategoria` não traz contagem de uso** e `getCategorias` não retorna uso — a lista não exibe "N simulados em uso" nem pré-desabilita o excluir por uso. Excluir é desabilitado apenas para categorias **seedadas** (`isProtegida`); para as demais, o **409** real (categoria em uso) é tratado no clique via toast — exatamente como a spec admite ("a verificação real vem do backend no click").
- **Preview do nome** espelha a fórmula real do backend (`gerarNomeAuto`), não a versão divergente do card.

## Sem botão "Editar"
Por design: categoria é imutável (CRUD sem update). Confirmado.

## Test Plan
- [x] `npm run build` (tsc + vite) passa sem erros de tipo
- [x] lint sem warnings nos arquivos novos/editados (`--max-warnings 0`)
- [ ] Smoke test end-to-end em homol (depende do deploy dos Cards 02/03 no backend):
  - [ ] Botão aparece só para admins com `alterarPermissao`
  - [ ] Criar categoria → aparece na lista e no select do `NewProva`
  - [ ] Excluir categoria sem uso → sucesso
  - [ ] Tentar excluir seedada em uso → toast informativo com contagem

Closes #640
Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
