### PR TITLE
feat(prova): fluxo condicional custom no NewProva (Card 05)

### DIFF
--- a/src/pages/dashProvas/modals/newProva.tsx
+++ b/src/pages/dashProvas/modals/newProva.tsx
@@ -71,13 +71,17 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
     }
   };
 
-  const handleRemoveGabarito = (_: any) => {
+  const handleRemoveGabarito = () => {
     setUploadGabarito(null);
   };
 
-  const handleRemoveFile = (_: any) => {
+  const handleRemoveFile = () => {
     setUploadFile(null);
   };
+
+  const categoria = watch("categoria");
+  const categoriaEscolhida = categorias.find((c) => c._id === categoria);
+  const isCustom = categoriaEscolhida?.custom === true;
 
   const listFieldProva: FormFieldInput[] = [
     {
@@ -88,6 +92,22 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
       label: "Categoria",
       disabled: false,
     },
+    ...(isCustom
+      ? ([
+          {
+            id: "nome",
+            type: "text",
+            label: "Nome da prova",
+            disabled: false,
+          },
+          {
+            id: "nomeSimulado",
+            type: "text",
+            label: "Nome do simulado",
+            disabled: false,
+          },
+        ] as FormFieldInput[])
+      : []),
     {
       id: "edicao",
       type: "option",
@@ -104,11 +124,15 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
     },
   ];
 
-  const categoria = watch("categoria");
-
   const create = async (data: any) => {
-    if (!uploadFile) {
-      toast.error("É necessaria fazer o upload do arquivo da prova");
+    if (!isCustom && !uploadFile) {
+      toast.error("Prova PDF é obrigatória para provas ENEM oficiais");
+      return;
+    }
+    if (isCustom && (!data.nome || !data.nomeSimulado)) {
+      toast.error(
+        "Nome da prova e do simulado são obrigatórios para provas personalizadas",
+      );
       return;
     }
 
@@ -129,13 +153,23 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
     formData.append("edicao", info.edicao);
     formData.append("ano", info.ano.toString());
     formData.append("aplicacao", info.aplicacao.toString());
-    formData.append("file", uploadFile!, `${fileName}.pdf`);
+
+    if (uploadFile) {
+      formData.append("file", uploadFile, `${fileName}.pdf`);
+    }
 
     if (uploadGabarito) {
       formData.append("gabarito", uploadGabarito!, `${fileName}_gabarito.pdf`);
     }
 
-    const title = `${info.ano}_${info.edicao}_${info.aplicacao}`;
+    if (isCustom) {
+      formData.append("nome", data.nome);
+      formData.append("nomeSimulado", data.nomeSimulado);
+    }
+
+    const title = isCustom
+      ? data.nome
+      : `${info.ano}_${info.edicao}_${info.aplicacao}`;
 
     await executeAsync({
       action: () => createProva(formData, token),
@@ -190,6 +224,12 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
             </div>
           </div>
 
+          {isCustom && (
+            <p className="text-xs text-blue-700 -mt-2">
+              Prova personalizada — nome livre, PDF opcional.
+            </p>
+          )}
+
           <div>
             <h3 className="text-sm font-medium text-gray-700 mb-4 flex items-center gap-2">
               <CloudArrowUpIcon className="h-4 w-4" />
@@ -240,7 +280,7 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
             <Button
               type="submit"
               variant="contained"
-              disabled={!categoria || !uploadFile}
+              disabled={!categoria || (!isCustom && !uploadFile)}
               sx={{
                 backgroundColor: "#3b82f6",
                 "&:hover": {


### PR DESCRIPTION
## Resumo

Card 05 da **Etapa 4 (Provas Custom)** — fecha a etapa no frontend. Adapta o modal `NewProva` para ter comportamento condicional quando a categoria escolhida é `custom: true`.

## O que mudou (`src/pages/dashProvas/modals/newProva.tsx`)
- Rastreia a categoria escolhida → `isCustom = categoriaEscolhida?.custom === true`
- **Custom**: campos `nome` e `nomeSimulado` aparecem e são **obrigatórios**; PDF/gabarito viram **opcionais**; `formData` inclui `nome`/`nomeSimulado`
- **Oficial (ENEM)**: fluxo intacto — PDF obrigatório, sem campos livres
- Validação de submit e `disabled` do botão adaptados por `isCustom`
- Hint visual discreto: _"Prova personalizada — nome livre, PDF opcional."_
- `criadorId` **não** vai no body (o api-vcnafacul injeta via JWT — Card 04)

## Correções vs. spec do card
- O card mandava trocar o filtro do select de `f.nome.includes("Enem")` para `f.selecionavel`, mas **o código já filtrava por `f.selecionavel`** (feito em etapa anterior) — nada a mudar aí.
- Fix trivial de **lint pré-existente** no mesmo arquivo (param `_` não usado em `handleRemoveGabarito`/`handleRemoveFile`) — necessário porque o gate do client é `--max-warnings 0` e eu estou tocando o arquivo. Confirmado idêntico na develop.

## Test Plan
- [x] `npm run build` (tsc + vite) passa
- [x] lint sem warnings (`--max-warnings 0`)
- [ ] Smoke em homol (depende de #160 ms-simulado + #504 api-vcnafacul deployados):
  - [ ] Select lista Enem Dia 1/2 + personalizadas (`selecionavel`)
  - [ ] Categoria custom → `nome`/`nomeSimulado` obrigatórios, PDF opcional, hint aparece
  - [ ] Categoria oficial → PDF obrigatório, sem campos livres (fluxo antigo)
  - [ ] Submeter custom sem nome → toast bloqueia; oficial sem PDF → toast bloqueia
  - [ ] Prova custom criada aparece na DashProva; `ShowProva` mostra **1 simulado**

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)
