### PR TITLE
[Janela Simulado] Card 04 · client · vista de simulados: janela + status + toast 403

### DIFF
--- a/src/dtos/prova/prova.ts
+++ b/src/dtos/prova/prova.ts
@@ -10,6 +10,8 @@ export interface SimuladoResumo {
   bloqueado: boolean;
   aproveitamento?: number;
   vezesRespondido?: number;
+  disponivelDe?: string | null; // ISO 8601 (UTC)
+  disponivelAte?: string | null;
 }
 
 export interface Prova {

--- a/src/pages/dashProvas/modals/editDisponibilidadeModal.tsx
+++ b/src/pages/dashProvas/modals/editDisponibilidadeModal.tsx
@@ -1,0 +1,135 @@
+import ModalTemplate from "@/components/templates/modalTemplate";
+import { useToastAsync } from "@/hooks/useToastAsync";
+import { Button } from "@mui/material";
+import { useState } from "react";
+import { SimuladoResumo } from "../../../dtos/prova/prova";
+import { updateDisponibilidade } from "../../../services/simulado/updateDisponibilidade";
+import { toDatetimeLocalValue } from "../../../utils/date";
+
+interface EditDisponibilidadeModalProps {
+  simulado: SimuladoResumo;
+  token: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved: (updated: SimuladoResumo) => void;
+}
+
+function EditDisponibilidadeModal({
+  simulado,
+  token,
+  isOpen,
+  onClose,
+  onSaved,
+}: EditDisponibilidadeModalProps) {
+  const executeAsync = useToastAsync();
+  const [de, setDe] = useState(toDatetimeLocalValue(simulado.disponivelDe));
+  const [ate, setAte] = useState(toDatetimeLocalValue(simulado.disponivelAte));
+  const [erro, setErro] = useState<string | null>(null);
+
+  const handleSalvar = async () => {
+    const deDate = de ? new Date(de) : null;
+    const ateDate = ate ? new Date(ate) : null;
+
+    if (deDate && ateDate && deDate >= ateDate) {
+      setErro("O início precisa ser antes do fim.");
+      return;
+    }
+    setErro(null);
+
+    await executeAsync({
+      action: () =>
+        updateDisponibilidade(
+          simulado._id,
+          { disponivelDe: deDate, disponivelAte: ateDate },
+          token,
+        ),
+      loadingMessage: "Salvando janela...",
+      successMessage: "Janela de disponibilidade atualizada",
+      errorMessage: (error) => error.message,
+      onSuccess() {
+        onSaved({
+          ...simulado,
+          disponivelDe: deDate ? deDate.toISOString() : null,
+          disponivelAte: ateDate ? ateDate.toISOString() : null,
+        });
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <ModalTemplate
+      isOpen={isOpen}
+      handleClose={onClose}
+      className="w-full max-w-md rounded-lg bg-white shadow-xl p-6"
+    >
+      <h3 className="text-lg font-semibold text-gray-900 mb-1">
+        Editar janela
+      </h3>
+      <p className="text-sm text-gray-500 mb-4">{simulado.nome}</p>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">
+            Disponível de
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              type="datetime-local"
+              value={de}
+              onChange={(e) => setDe(e.target.value)}
+              className="border border-gray-300 rounded px-2 py-1 text-sm w-full"
+            />
+            {de && (
+              <button
+                type="button"
+                onClick={() => setDe("")}
+                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                aria-label="Limpar disponível de"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">
+            Disponível até
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              type="datetime-local"
+              value={ate}
+              onChange={(e) => setAte(e.target.value)}
+              className="border border-gray-300 rounded px-2 py-1 text-sm w-full"
+            />
+            {ate && (
+              <button
+                type="button"
+                onClick={() => setAte("")}
+                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                aria-label="Limpar disponível até"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        </div>
+
+        {erro && <p className="text-sm text-red-600">{erro}</p>}
+      </div>
+
+      <div className="flex justify-end gap-3 mt-6">
+        <Button variant="outlined" onClick={onClose}>
+          Cancelar
+        </Button>
+        <Button variant="contained" onClick={handleSalvar}>
+          Salvar
+        </Button>
+      </div>
+    </ModalTemplate>
+  );
+}
+
+export default EditDisponibilidadeModal;

--- a/src/pages/dashProvas/modals/editDisponibilidadeModal.tsx
+++ b/src/pages/dashProvas/modals/editDisponibilidadeModal.tsx
@@ -62,6 +62,7 @@ function EditDisponibilidadeModal({
       isOpen={isOpen}
       handleClose={onClose}
       className="w-full max-w-md rounded-lg bg-white shadow-xl p-6"
+      style={{ zIndex: 60 }}
     >
       <h3 className="text-lg font-semibold text-gray-900 mb-1">
         Editar janela

--- a/src/pages/dashProvas/modals/showProva.tsx
+++ b/src/pages/dashProvas/modals/showProva.tsx
@@ -393,8 +393,21 @@ const downloadFile = async (filename: string, fileType: string) => {
             simulados={fullProva?.simulados}
             loading={loadingSimulados}
             error={errorSimulados}
+            token={token}
             onVoltar={() => setView('details')}
             onRetry={() => setRetryCount(c => c + 1)}
+            onSimuladoUpdated={(updated) =>
+              setFullProva((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      simulados: prev.simulados?.map((s) =>
+                        s._id === updated._id ? updated : s,
+                      ),
+                    }
+                  : prev,
+              )
+            }
           />
         )}
         </div>

--- a/src/pages/dashProvas/modals/simuladosView.tsx
+++ b/src/pages/dashProvas/modals/simuladosView.tsx
@@ -1,16 +1,58 @@
-import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
 import { Button } from "@mui/material";
+import { useState } from "react";
 import { SimuladoResumo } from "../../../dtos/prova/prova";
+import { formatDateTime } from "../../../utils/date";
+import { getStatus, isSemJanela } from "../../../utils/simuladoAvailability";
+import EditDisponibilidadeModal from "./editDisponibilidadeModal";
 
 interface SimuladosViewProps {
   simulados: SimuladoResumo[] | undefined;
   loading: boolean;
   error: string | null;
+  token: string;
   onVoltar: () => void;
   onRetry: () => void;
+  onSimuladoUpdated: (updated: SimuladoResumo) => void;
 }
 
-function SimuladosView({ simulados, loading, error, onVoltar, onRetry }: SimuladosViewProps) {
+function renderStatus(simulado: SimuladoResumo) {
+  const status = getStatus(simulado);
+  switch (status) {
+    case "bloqueado":
+      return <span className="text-gray-600">🔒 Aprovação pendente</span>;
+    case "antes_da_janela":
+      return (
+        <span className="text-yellow-700">
+          🟡 Abre em {formatDateTime(simulado.disponivelDe)}
+        </span>
+      );
+    case "depois_da_janela":
+      return (
+        <span className="text-red-700">
+          🔴 Expirou em {formatDateTime(simulado.disponivelAte)}
+        </span>
+      );
+    default:
+      return isSemJanela(simulado) ? (
+        <span className="text-gray-500">⚪ Sem janela</span>
+      ) : (
+        <span className="text-green-700">🟢 Disponível</span>
+      );
+  }
+}
+
+function SimuladosView({
+  simulados,
+  loading,
+  error,
+  token,
+  onVoltar,
+  onRetry,
+  onSimuladoUpdated,
+}: SimuladosViewProps) {
+  const [editing, setEditing] = useState<SimuladoResumo | null>(null);
+
   return (
     <div>
       <button
@@ -33,7 +75,9 @@ function SimuladosView({ simulados, loading, error, onVoltar, onRetry }: Simulad
 
       {!loading && error && (
         <div className="text-center py-8">
-          <p className="text-sm text-red-600 mb-3">Não foi possível carregar os simulados.</p>
+          <p className="text-sm text-red-600 mb-3">
+            Não foi possível carregar os simulados.
+          </p>
           <Button variant="outlined" size="small" onClick={onRetry}>
             Tentar novamente
           </Button>
@@ -54,35 +98,59 @@ function SimuladosView({ simulados, loading, error, onVoltar, onRetry }: Simulad
                 <th className="px-3 py-2">Nome</th>
                 <th className="px-3 py-2">Categoria</th>
                 <th className="px-3 py-2">Questões</th>
-                <th className="px-3 py-2">Aproveitamento</th>
-                <th className="px-3 py-2">Respondido</th>
+                <th className="px-3 py-2">Disponível de</th>
+                <th className="px-3 py-2">Disponível até</th>
                 <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {simulados.map((simulado) => (
                 <tr key={simulado._id} className="hover:bg-gray-50">
-                  <td className="px-3 py-2 font-medium text-gray-900">{simulado.nome}</td>
-                  <td className="px-3 py-2 text-gray-600">
-                    {simulado.categoria?.nome ?? '—'}
+                  <td className="px-3 py-2 font-medium text-gray-900">
+                    {simulado.nome}
                   </td>
                   <td className="px-3 py-2 text-gray-600">
-                    {simulado.questoes.length}/{simulado.categoria?.quantidadeTotalQuestao ?? '-'}
+                    {simulado.categoria?.nome ?? "—"}
                   </td>
                   <td className="px-3 py-2 text-gray-600">
-                    {simulado.aproveitamento ?? 0}
+                    {simulado.questoes.length}/
+                    {simulado.categoria?.quantidadeTotalQuestao ?? "-"}
                   </td>
                   <td className="px-3 py-2 text-gray-600">
-                    {simulado.vezesRespondido ?? 0}x
+                    {formatDateTime(simulado.disponivelDe) || "—"}
                   </td>
+                  <td className="px-3 py-2 text-gray-600">
+                    {formatDateTime(simulado.disponivelAte) || "—"}
+                  </td>
+                  <td className="px-3 py-2">{renderStatus(simulado)}</td>
                   <td className="px-3 py-2">
-                    {simulado.bloqueado ? '🔒 Bloqueado' : '✅ Liberado'}
+                    <button
+                      onClick={() => setEditing(simulado)}
+                      className="text-gray-400 hover:text-blue-600"
+                      aria-label="Editar janela"
+                    >
+                      <PencilSquareIcon className="h-4 w-4" />
+                    </button>
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
+      )}
+
+      {editing && (
+        <EditDisponibilidadeModal
+          simulado={editing}
+          token={token}
+          isOpen={!!editing}
+          onClose={() => setEditing(null)}
+          onSaved={(updated) => {
+            onSimuladoUpdated(updated);
+            setEditing(null);
+          }}
+        />
       )}
     </div>
   );

--- a/src/pages/mainSimulate/modals/newSimulate.tsx
+++ b/src/pages/mainSimulate/modals/newSimulate.tsx
@@ -48,9 +48,7 @@ function NewSimulate({ handleClose, title, isOpen }: NewSimulateProps) {
         toast.success(`Iniciado Simulado ${res.title}`);
       })
       .catch((error: Error) => {
-        toast.error(
-          `Erro ao buscar simulado ${availableSelected.id} - Error ${error.message}`
-        );
+        toast.error(error.message);
       });
   };
 

--- a/src/services/simulado/getSimuladoById.ts
+++ b/src/services/simulado/getSimuladoById.ts
@@ -27,7 +27,16 @@ export async function getSimuladoById(id: string, token: string) {
     },
   });
   if (response.status !== 200) {
-    throw new Error(`Erro ao buscar simulado`);
+    const body = await response.json().catch(() => ({}));
+    if (response.status === 403) {
+      const mensagens: Record<string, string> = {
+        antes_da_janela: "Esse simulado ainda não abriu.",
+        depois_da_janela: "Esse simulado não está mais disponível.",
+        bloqueado: "Esse simulado ainda está sendo preparado.",
+      };
+      throw new Error(mensagens[body?.status] || "Simulado indisponível.");
+    }
+    throw new Error("Erro ao buscar simulado");
   }
 
   const res: ISimuladoDTO = await response.json();

--- a/src/services/simulado/updateDisponibilidade.ts
+++ b/src/services/simulado/updateDisponibilidade.ts
@@ -1,0 +1,35 @@
+import fetchWrapper from "../../utils/fetchWrapper";
+import { simulado } from "../urls";
+
+export interface DisponibilidadeInput {
+  disponivelDe: Date | null;
+  disponivelAte: Date | null;
+}
+
+export async function updateDisponibilidade(
+  simuladoId: string,
+  input: DisponibilidadeInput,
+  token: string,
+) {
+  const response = await fetchWrapper(
+    `${simulado}/${simuladoId}/disponibilidade`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        disponivelDe: input.disponivelDe ? input.disponivelDe.toISOString() : null,
+        disponivelAte: input.disponivelAte
+          ? input.disponivelAte.toISOString()
+          : null,
+      }),
+    },
+  );
+  if (response.status !== 200) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.message || "Erro ao atualizar disponibilidade");
+  }
+  return response.json();
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,3 +2,14 @@ import { format } from "date-fns";
 
 export const formatDate = (dateString?: string, formatString: string = "dd/MM/yyyy") =>
   dateString ? format(new Date(dateString), formatString) : "";
+
+/** Exibe data+hora local, ex: "10/01/2026 08:00". Vazio se null/undefined. */
+export const formatDateTime = (dateString?: string | null) =>
+  dateString ? format(new Date(dateString), "dd/MM/yyyy HH:mm") : "";
+
+/**
+ * Converte um ISO (UTC) para o valor esperado por <input type="datetime-local">
+ * no fuso LOCAL do usuário: "yyyy-MM-ddTHH:mm". Vazio se null/undefined.
+ */
+export const toDatetimeLocalValue = (dateString?: string | null) =>
+  dateString ? format(new Date(dateString), "yyyy-MM-dd'T'HH:mm") : "";

--- a/src/utils/simuladoAvailability.ts
+++ b/src/utils/simuladoAvailability.ts
@@ -1,0 +1,34 @@
+import { SimuladoResumo } from "../dtos/prova/prova";
+
+export type AvailabilityStatus =
+  | "disponivel"
+  | "bloqueado"
+  | "antes_da_janela"
+  | "depois_da_janela";
+
+/**
+ * Espelha getAvailabilityStatus do ms-simulado (availability.ts).
+ * Duplicação intencional: o backend é a fonte de verdade nas decisões
+ * críticas (gate 403 em getToAnswer); aqui é só para render.
+ */
+export function getStatus(
+  simulado: Pick<
+    SimuladoResumo,
+    "bloqueado" | "disponivelDe" | "disponivelAte"
+  >,
+  now: Date = new Date(),
+): AvailabilityStatus {
+  if (simulado.bloqueado) return "bloqueado";
+  const de = simulado.disponivelDe ? new Date(simulado.disponivelDe) : null;
+  const ate = simulado.disponivelAte ? new Date(simulado.disponivelAte) : null;
+  if (de && now < de) return "antes_da_janela";
+  if (ate && now > ate) return "depois_da_janela";
+  return "disponivel";
+}
+
+/** true quando disponível sem janela definida (null/null) → estado "⚪ Sem janela". */
+export function isSemJanela(
+  simulado: Pick<SimuladoResumo, "disponivelDe" | "disponivelAte">,
+): boolean {
+  return !simulado.disponivelDe && !simulado.disponivelAte;
+}


### PR DESCRIPTION
## [Janela Simulado] Card 04 · client-vcnafacul · Vista de simulados: janela + status + toast 403

Etapa 5 (Janela Simulado). Fecha a série no frontend: exibe/edita a janela de disponibilidade dos simulados na vista do `ShowProva` e trata o 403 do gate no fluxo do aluno. Depende de ms-simulado#164 + api-vcnafacul#506.

### Vista de simulados do ShowProva (admin)
- 2 colunas novas: **Disponível de** / **Disponível até** (formatadas, ou `—`).
- Coluna de **Status** com 5 estados: 🟢 Disponível · ⚪ Sem janela · 🟡 Abre em {data} · 🔴 Expirou em {data} · 🔒 Aprovação pendente.
- Botão ✏️ por linha abre um **modal "Editar janela"** com dois `datetime-local` + botões `×` para limpar (envia `null`), validação inline `de < até`, e um único PATCH com ambas as datas.
- Estado atualizado de forma imutável no `ShowProva` após salvar (sem refetch).

### Fluxo do aluno
- O 403 do gate (`getToAnswer`) agora é traduzido em mensagem amigável por `status` (`antes_da_janela` / `depois_da_janela` / `bloqueado`) — antes o corpo era descartado e virava um erro genérico.
- Grace period preservado (submissão não é gated no backend).

### Detalhes técnicos
- **Timezone:** `datetime-local` (local) → `toISOString()` (UTC) no envio; leitura ISO → render local via date-fns. Round-trip verificado.
- `getStatus` (client) espelha `getAvailabilityStatus` do ms-simulado — duplicação intencional (backend é a fonte de verdade nas decisões críticas via 403).
- Sem mudança de backend: os campos já fluem via `getProvaById` (populate sem select restritivo no ms + passthrough no api).
- Build ok. (Nota: `npm run lint` está quebrado no repo por ESLint 9 sem flat config — **pré-existente no develop**, não deste card; os arquivos deste PR foram lintados via config legada, zero warnings.)

### Arquivos
`SimuladoResumo` (+2 campos) · `utils/date` (formatDateTime + toDatetimeLocalValue) · `utils/simuladoAvailability` (getStatus) · `services/simulado/updateDisponibilidade` · `getSimuladoById` (403) · `newSimulate` (toast) · `editDisponibilidadeModal` (novo) · `simuladosView` · `showProva`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
