### PR TITLE
feat(provas-cursinho): UI de permissões + página PartnerPrepProvas (Etapa 6 Cards 04+05)

### DIFF
--- a/src/dtos/roles/createRole.ts
+++ b/src/dtos/roles/createRole.ts
@@ -30,4 +30,6 @@ export interface CreateRoleDto {
   supportAgent: boolean;
   partnerPrepSupportAgent: boolean;
   editarMateriasFrentes: boolean;
+  visualizarProvasCursinho: boolean;
+  cadastrarProvasCursinho: boolean;
 }

--- a/src/enums/roles/roles.ts
+++ b/src/enums/roles/roles.ts
@@ -27,6 +27,8 @@ export enum Roles {
   supportAgent = "supportAgent",
   partnerPrepSupportAgent = "partnerPrepSupportAgent",
   editarMateriasFrentes = "editarMateriasFrentes",
+  visualizarProvasCursinho = "visualizarProvasCursinho",
+  cadastrarProvasCursinho = "cadastrarProvasCursinho",
 }
 
 export const RolesLabel = [

--- a/src/pages/dash/data.ts
+++ b/src/pages/dash/data.ts
@@ -28,6 +28,7 @@ import {
   PARTNER_CLASS_STUDENTS,
   PARTNER_PREP_INSCRIPTION,
   PARTNER_PREP_MANAGER,
+  PARTNER_PROVAS,
   REGISTRATION_MONITOR,
   SIMULADO,
 } from "../../routes/path";
@@ -130,6 +131,13 @@ export const adminMenuItems: DashCardMenu[] = [
         text: "Formulário",
         link: `/dashboard/${PARTNER_CLASS_FORM}`,
         permissions: [Roles.gerenciarFormulario],
+      },
+      {
+        icon: Fisica,
+        alt: "provas cursinho",
+        text: "Provas",
+        link: `/dashboard/${PARTNER_PROVAS}`,
+        permissions: [Roles.visualizarProvasCursinho],
       },
       {
         icon: FaBook,

--- a/src/pages/dashProvas/modals/newProva.tsx
+++ b/src/pages/dashProvas/modals/newProva.tsx
@@ -28,9 +28,10 @@ interface NewProvaProps extends ModalProps {
   addProva: (data: Prova) => void;
   categorias: ICategoria[];
   isOpen: boolean;
+  createService?: (data: FormData, token: string) => Promise<Prova>;
 }
 
-function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) {
+function NewProva({ addProva, categorias, handleClose, isOpen, createService }: NewProvaProps) {
   const { register, handleSubmit, watch } = useForm();
   const {
     data: { token },
@@ -172,7 +173,7 @@ function NewProva({ addProva, categorias, handleClose, isOpen }: NewProvaProps) 
       : `${info.ano}_${info.edicao}_${info.aplicacao}`;
 
     await executeAsync({
-      action: () => createProva(formData, token),
+      action: () => (createService ?? createProva)(formData, token),
       loadingMessage: "Criando Prova...",
       successMessage: `Prova ${title} criada com sucesso`,
       errorMessage: (error) => error.message,

--- a/src/pages/dashRoles/modals/ModalNewRole.tsx
+++ b/src/pages/dashRoles/modals/ModalNewRole.tsx
@@ -54,6 +54,8 @@ const EMPTY_ROLE: CreateRoleDto = {
   supportAgent: false,
   partnerPrepSupportAgent: false,
   editarMateriasFrentes: false,
+  visualizarProvasCursinho: false,
+  cadastrarProvasCursinho: false,
 };
 
 function applyBaseRoleConstraints(

--- a/src/pages/managerCollaborator/modals/ModalNewRole.tsx
+++ b/src/pages/managerCollaborator/modals/ModalNewRole.tsx
@@ -57,6 +57,8 @@ const EMPTY_ROLE: CreateRoleDto = {
   supportAgent: false,
   partnerPrepSupportAgent: false,
   editarMateriasFrentes: false,
+  visualizarProvasCursinho: false,
+  cadastrarProvasCursinho: false,
 };
 
 function ModalNewRole({

--- a/src/pages/partnerPrepProvas/data.ts
+++ b/src/pages/partnerPrepProvas/data.ts
@@ -1,0 +1,3 @@
+export const partnerPrepProva = {
+  title: "Provas do Cursinho",
+};

--- a/src/pages/partnerPrepProvas/index.tsx
+++ b/src/pages/partnerPrepProvas/index.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import { FilterProps } from "../../components/atoms/filter";
+import { SelectProps } from "../../components/atoms/select";
+import { OptionProps } from "../../components/atoms/selectOption";
+import { ButtonProps } from "../../components/molecules/button";
+import { CardDash } from "../../components/molecules/cardDash";
+import DashCardTemplate from "../../components/templates/dashCardTemplate";
+import { DashCardContext } from "../../context/dashCardContext";
+import { Prova } from "../../dtos/prova/prova";
+import { ICategoria } from "../../dtos/categoria/categoria";
+import { StatusEnum } from "../../enums/generic/statusEnum";
+import { Roles } from "../../enums/roles/roles";
+import { getProvasCursinho } from "../../services/prova/getProvasCursinho";
+import { createProvaCursinho } from "../../services/prova/createProvaCursinho";
+import { getCategorias } from "../../services/categoria/getCategorias";
+import { useAuthStore } from "../../store/auth";
+import { formatDate } from "../../utils/date";
+import { Paginate } from "../../utils/paginate";
+import { partnerPrepProva } from "./data";
+import NewProva from "../dashProvas/modals/newProva";
+import ShowProva from "../dashProvas/modals/showProva";
+import { useModals } from "@/hooks/useModal";
+
+const EDICAO_ALL = "";
+const APLICACAO_ALL = "";
+const ANO_ALL = "";
+
+function PartnerPrepProvas() {
+  const [provas, setProvas] = useState<Prova[]>([]);
+  const [provaSelected, setProvaSelected] = useState<Prova | null>(null);
+
+  const [categorias, setCategorias] = useState<ICategoria[]>();
+
+  const [nameFilter, setNameFilter] = useState<string>("");
+  const [edicaoFilter, setEdicaoFilter] = useState<string>(EDICAO_ALL);
+  const [aplicacaoFilter, setAplicacaoFilter] =
+    useState<string>(APLICACAO_ALL);
+  const [anoFilter, setAnoFilter] = useState<string>(ANO_ALL);
+  const [gabaritoOnly, setGabaritoOnly] = useState<boolean>(false);
+  const [resetKey, setResetKey] = useState<number>(0);
+
+  const limitCards = 500;
+
+  const modals = useModals(['modalNewProva', 'modalShowProva']);
+
+  const {
+    data: { token, permissao },
+  } = useAuthStore();
+
+  const cardTransformation = (prova: Prova): CardDash => ({
+    id: prova._id,
+    title: prova.nome,
+    status:
+      prova.totalQuestao === prova.totalQuestaoValidadas
+        ? StatusEnum.Approved
+        : prova.totalQuestao === prova.totalQuestaoCadastradas
+        ? StatusEnum.Pending
+        : StatusEnum.Rejected,
+    infos: [
+      { field: "Total de Questões", value: prova.totalQuestao.toString() },
+      {
+        field: "Total de Questões Cadastradas",
+        value: prova.totalQuestaoCadastradas.toString(),
+      },
+      {
+        field: "Total de Questões Validadas",
+        value: prova.totalQuestaoValidadas.toString(),
+      },
+      {
+        field: "Cadastrado em ",
+        value: prova.createdAt ? formatDate(prova.createdAt.toString()) : "",
+      },
+    ],
+  });
+
+  const onClickCard = (id: string | number) => {
+    setProvaSelected(provas.find((p) => p._id === id)!);
+    modals.modalShowProva.open();
+  };
+
+  const addProva = (data: Prova) => {
+    const newProvas = [...provas, data];
+    setProvas(newProvas);
+  };
+
+  const ModalNewProva = () => {
+    return !modals.modalNewProva.isOpen ? null : (
+      <NewProva
+        categorias={categorias!}
+        addProva={addProva}
+        createService={createProvaCursinho}
+        handleClose={() => modals.modalNewProva.close()}
+        isOpen={modals.modalNewProva.isOpen}
+      />
+    );
+  };
+
+  const ModalShowProva = () => {
+    return !modals.modalShowProva.isOpen ? null : (
+      <ShowProva
+        prova={provaSelected!}
+        handleClose={() => {
+          modals.modalShowProva.close();
+        }}
+        isOpen={modals.modalShowProva.isOpen}
+        onUpdated={(updated) => {
+          setProvas((prev) =>
+            prev.map((p) => (p._id === updated._id ? updated : p))
+          );
+          setProvaSelected(updated);
+        }}
+      />
+    );
+  };
+
+  useEffect(() => {
+    getProvasCursinho(token, 1, limitCards)
+      .then((res) => {
+        setProvas(res.data);
+      })
+      .catch((erro: Error) => {
+        toast.error(erro.message);
+      });
+
+    getCategorias(token)
+      .then((res) => {
+        setCategorias(res.data);
+      })
+      .catch((erro: Error) => {
+        toast.error(erro.message);
+      });
+  }, [token]);
+
+  const getMoreCards = async (page: number): Promise<Paginate<Prova>> => {
+    return await getProvasCursinho(token, page, limitCards);
+  };
+
+  const edicaoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<string>();
+    provas.forEach((p) => {
+      if (p.edicao) set.add(p.edicao);
+    });
+    return [
+      { id: EDICAO_ALL, name: "Todas edições" },
+      ...Array.from(set)
+        .sort((a, b) => a.localeCompare(b))
+        .map((v) => ({ id: v, name: v })),
+    ];
+  }, [provas]);
+
+  const aplicacaoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<number>();
+    provas.forEach((p) => {
+      if (p.aplicacao !== undefined && p.aplicacao !== null)
+        set.add(p.aplicacao);
+    });
+    return [
+      { id: APLICACAO_ALL, name: "Todas aplicações" },
+      ...Array.from(set)
+        .sort((a, b) => a - b)
+        .map((v) => ({ id: v.toString(), name: v.toString() })),
+    ];
+  }, [provas]);
+
+  const anoOptions: OptionProps[] = useMemo(() => {
+    const set = new Set<number>();
+    provas.forEach((p) => {
+      if (p.ano !== undefined && p.ano !== null) set.add(p.ano);
+    });
+    return [
+      { id: ANO_ALL, name: "Todos os anos" },
+      ...Array.from(set)
+        .sort((a, b) => b - a)
+        .map((v) => ({ id: v.toString(), name: v.toString() })),
+    ];
+  }, [provas]);
+
+  const filteredProvas = useMemo(() => {
+    const term = nameFilter.trim().toLowerCase();
+    return provas.filter((p) => {
+      if (term && !p.nome?.toLowerCase().includes(term)) return false;
+      if (edicaoFilter && p.edicao !== edicaoFilter) return false;
+      if (aplicacaoFilter && p.aplicacao?.toString() !== aplicacaoFilter)
+        return false;
+      if (anoFilter && p.ano?.toString() !== anoFilter) return false;
+      if (gabaritoOnly && !p.gabarito) return false;
+      return true;
+    });
+  }, [provas, nameFilter, edicaoFilter, aplicacaoFilter, anoFilter, gabaritoOnly]);
+
+  const filterProps: FilterProps = {
+    placeholder: "Buscar por nome",
+    filtrar: (e: React.ChangeEvent<HTMLInputElement>) =>
+      setNameFilter(e.target.value),
+    defaultValue: nameFilter,
+  };
+
+  const selectFiltes: SelectProps[] = [
+    {
+      options: edicaoOptions,
+      defaultValue: edicaoFilter,
+      setState: (value: string) => setEdicaoFilter(value),
+    },
+    {
+      options: aplicacaoOptions,
+      defaultValue: aplicacaoFilter,
+      setState: (value: string) => setAplicacaoFilter(value),
+    },
+    {
+      options: anoOptions,
+      defaultValue: anoFilter,
+      setState: (value: string) => setAnoFilter(value),
+    },
+  ];
+
+  const hasActiveFilters =
+    nameFilter !== "" ||
+    edicaoFilter !== EDICAO_ALL ||
+    aplicacaoFilter !== APLICACAO_ALL ||
+    anoFilter !== ANO_ALL ||
+    gabaritoOnly;
+
+  const clearFilters = () => {
+    setNameFilter("");
+    setEdicaoFilter(EDICAO_ALL);
+    setAplicacaoFilter(APLICACAO_ALL);
+    setAnoFilter(ANO_ALL);
+    setGabaritoOnly(false);
+    setResetKey((k) => k + 1);
+  };
+
+  const buttons: ButtonProps[] = [
+    {
+      disabled: !permissao[Roles.cadastrarProvasCursinho],
+      onClick: () => {
+        setProvaSelected(null);
+        modals.modalNewProva.open();
+      },
+      typeStyle: "quaternary",
+      size: "small",
+      children: "Nova Prova",
+    },
+    {
+      disabled: !hasActiveFilters,
+      onClick: clearFilters,
+      typeStyle: "refused",
+      size: "small",
+      children: "Limpar filtros",
+    },
+  ];
+
+  const GabaritoCheckbox = (
+    <label className="flex items-center gap-2 text-sm font-medium text-marine cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={gabaritoOnly}
+        onChange={(e) => setGabaritoOnly(e.target.checked)}
+        className="w-4 h-4 accent-marine cursor-pointer"
+      />
+      Só com gabarito
+    </label>
+  );
+
+  return (
+    <DashCardContext.Provider
+      value={{
+        title: partnerPrepProva.title,
+        entities: filteredProvas,
+        setEntities: setProvas,
+        onClickCard,
+        getMoreCards,
+        cardTransformation,
+        limitCards,
+        filterProps,
+        selectFiltes,
+        buttons,
+        totalItems: filteredProvas.length,
+      }}
+    >
+      <DashCardTemplate key={resetKey} customFilter={[GabaritoCheckbox]} />
+      <ModalNewProva />
+      <ModalShowProva />
+    </DashCardContext.Provider>
+  );
+}
+
+export default PartnerPrepProvas;

--- a/src/routes/PlatformRoutes.tsx
+++ b/src/routes/PlatformRoutes.tsx
@@ -37,6 +37,7 @@ import DashContent from "../pages/dashContent";
 import DashGeo from "../pages/dashGeo";
 import DashNews from "../pages/dashNews";
 import DashProva from "../pages/dashProvas";
+import PartnerPrepProvas from "../pages/partnerPrepProvas";
 import DashQuestionNew from "../pages/dashQuestionNew";
 import DashRoles from "../pages/dashRoles";
 import Forgot from "../pages/forgot";
@@ -95,6 +96,7 @@ import {
   PARTNER_PREP,
   PARTNER_PREP_INSCRIPTION,
   PARTNER_PREP_MANAGER,
+  PARTNER_PROVAS,
   REGISTER_PATH,
   REGISTRATION_MONITOR,
   RESET_PASSWORD_PATH,
@@ -326,6 +328,17 @@ export function PlatformRoutes() {
               permission={data.permissao[Roles.visualizarProvas]}
             >
               <DashProva />
+            </ProtectedRoutePermission>
+          }
+        />
+
+        <Route
+          path={PARTNER_PROVAS}
+          element={
+            <ProtectedRoutePermission
+              permission={data.permissao[Roles.visualizarProvasCursinho]}
+            >
+              <PartnerPrepProvas />
             </ProtectedRoutePermission>
           }
         />

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -34,6 +34,7 @@ export const MANAGER_COLLABORATOR = "colaboradores";
 export const PARTNER_CLASS = "turmas";
 export const PARTNER_CLASS_STUDENTS = "alunos";
 export const PARTNER_PREP_MANAGER = "gerenciamento-cursinho";
+export const PARTNER_PROVAS = "cursinho-provas";
 export const PARTNER_CLASS_FORM = "formulario";
 export const DASH_GLOBAL_FORM = "formulario-global";
 export const REGISTRATION_MONITOR = "acompanhamento-inscricoes";

--- a/src/services/prova/createProvaCursinho.ts
+++ b/src/services/prova/createProvaCursinho.ts
@@ -1,0 +1,21 @@
+import { Prova } from "../../dtos/prova/prova";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { cursinhoProva } from "../urls";
+
+export async function createProvaCursinho(
+  data: FormData,
+  token: string,
+): Promise<Prova> {
+  const response = await fetchWrapper(cursinhoProva, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: data,
+  });
+  if (response.status !== 201) {
+    const res = await response.json();
+    if (response.status === 403) {
+      throw new Error(res.message);
+    }
+  }
+  return await response.json();
+}

--- a/src/services/prova/getProvasCursinho.ts
+++ b/src/services/prova/getProvasCursinho.ts
@@ -1,0 +1,26 @@
+import { Prova } from "../../dtos/prova/prova";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { Paginate } from "../../utils/paginate";
+import { cursinhoProva } from "../urls";
+
+export async function getProvasCursinho(
+  token: string,
+  page: number = 1,
+  limit: number = 1,
+): Promise<Paginate<Prova>> {
+  const response = await fetchWrapper(
+    `${cursinhoProva}?page=${page}&limit=${limit}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  const res = await response.json();
+  if (response.status !== 200) {
+    throw new Error(`Erro ao buscar Provas do Cursinho ${res.message}`);
+  }
+  return res;
+}

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -57,6 +57,7 @@ export const report = `${simulado}/report`;
 export const prova = `${mssimulado}/prova`;
 export const provaById = (id: string) => `${prova}/${id}`;
 export const missing = `${prova}/missing`;
+export const cursinhoProva = `${mssimulado}/cursinho/prova`;
 export const questoes = `${mssimulado}/questoes`;
 export const historico = `${mssimulado}/historico`;
 export const auditLog = `${BASE_URL}/auditlog`;


### PR DESCRIPTION
## Etapa 6 · Cards 04 + 05 — client-vcnafacul

Cadeia encadeada (Card 04 → Card 05). Destrava a área "Provas" no dash do cursinho.

### Card 04 — Permissões na UI de Roles
A UI de permissões já é **data-driven do backend** (`getPermissionsHierarchy` → `PermissionHierarchyPanel`), então o grupo "Provas (Cursinho)" do backend renderiza sozinho. Só alinhamos tipos/estados:
- Enum `Roles` +2; `CreateRoleDto` +2 (`EditRoleDto` herda); `EMPTY_ROLE` +2 nos 2 modais de novo perfil.

### Card 05 — Página `PartnerPrepProvas`
- Services `getProvasCursinho` + `createProvaCursinho` (POST **multipart FormData**) → `/mssimulado/cursinho/prova`.
- `NewProva` ganha prop opcional `createService` (fallback pro `createProva` admin — sem fork, sem regressão no admin).
- Página `PartnerPrepProvas`: mirror enxuto do `dashProvas` (mesma estrutura `DashCardContext`), **sem** Sincronizar/Relatório/Gerenciar Categorias — só "Nova Prova" (gated `cadastrarProvasCursinho`) + "Limpar filtros". Reusa `ShowProva`.
- Rota `cursinho-provas` protegida por `visualizarProvasCursinho`; entrada "Provas" no menu do grupo Cursinho.

### Testes
`npm run build` verde (gate; sem test runner de unidade pra isso). dashProvas admin sem regressão.

⚠️ **Deploy:** por último (depois de ms-simulado e api-vcnafacul).

Parte da série Provas Cursinho (etapa 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)