### PR TITLE
Etapa 11 — Gestão de vínculos multi-prova + provaBase (client)

### DIFF
--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/ModalAddQuestionToProva.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/ModalAddQuestionToProva.tsx
@@ -1,0 +1,150 @@
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getMissingNumber } from "@/services/prova/getMissingNumber";
+import { useAuthStore } from "@/store/auth";
+import { Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { ProvaOption } from "./types";
+
+interface ModalAddQuestionToProvaProps {
+  provas: ProvaOption[];
+  provaIdsJaVinculadas: string[];
+  onConfirm: (provaId: string, numero: number) => Promise<void>;
+  onClose: () => void;
+}
+
+export function ModalAddQuestionToProva({
+  provas,
+  provaIdsJaVinculadas,
+  onConfirm,
+  onClose,
+}: ModalAddQuestionToProvaProps) {
+  const {
+    data: { token },
+  } = useAuthStore();
+
+  const [busca, setBusca] = useState("");
+  const [provaId, setProvaId] = useState<string | null>(null);
+  const [numero, setNumero] = useState<number | null>(null);
+  const [numeros, setNumeros] = useState<number[]>([]);
+  const [loadingNumeros, setLoadingNumeros] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const provasDisponiveis = useMemo(
+    () =>
+      provas
+        .filter((p) => !provaIdsJaVinculadas.includes(p._id))
+        .filter((p) => p.nome.toLowerCase().includes(busca.toLowerCase())),
+    [provas, provaIdsJaVinculadas, busca]
+  );
+
+  useEffect(() => {
+    setNumero(null);
+    if (!provaId) {
+      setNumeros([]);
+      return;
+    }
+    setLoadingNumeros(true);
+    getMissingNumber(provaId, token)
+      .then((ns) => setNumeros([...ns].sort((a, b) => a - b)))
+      .catch(() => setNumeros([]))
+      .finally(() => setLoadingNumeros(false));
+  }, [provaId, token]);
+
+  const handleConfirm = async () => {
+    if (!provaId || numero == null) return;
+    setSaving(true);
+    try {
+      await onConfirm(provaId, numero);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md space-y-4">
+        <h3 className="text-lg font-bold">Adicionar em uma prova</h3>
+
+        <div className="space-y-2">
+          <label className="text-sm font-semibold text-gray-600">Prova</label>
+          <input
+            type="text"
+            value={busca}
+            onChange={(e) => {
+              setBusca(e.target.value);
+              setProvaId(null);
+            }}
+            placeholder="Buscar prova por nome..."
+            className="w-full border rounded-md p-2 text-sm"
+          />
+          <div className="max-h-40 overflow-y-auto border rounded-md">
+            {provasDisponiveis.map((p) => (
+              <button
+                key={p._id}
+                onClick={() => setProvaId(p._id)}
+                className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-100 ${
+                  provaId === p._id ? "bg-blue-50 font-medium" : ""
+                }`}
+              >
+                {p.nome}
+              </button>
+            ))}
+            {provasDisponiveis.length === 0 && (
+              <p className="px-3 py-2 text-sm text-gray-400">
+                Nenhuma prova disponível
+              </p>
+            )}
+          </div>
+        </div>
+
+        {provaId && (
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-gray-600">Número</label>
+            {loadingNumeros ? (
+              <div className="flex items-center gap-2 text-sm text-gray-600">
+                <Loader2 className="h-4 w-4 animate-spin" /> Carregando números...
+              </div>
+            ) : (
+              <Select
+                value={numero != null ? String(numero) : undefined}
+                onValueChange={(v) => setNumero(parseInt(v, 10))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione o número" />
+                </SelectTrigger>
+                <SelectContent>
+                  {numeros.map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      Questão {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!provaId || numero == null || saving}
+            className="bg-primary"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : "Adicionar"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/index.tsx
@@ -30,6 +30,7 @@ import { Controller } from "react-hook-form";
 import { toast } from "react-toastify";
 import { TabClassificacaoProps } from "./types";
 import { useClassificacaoForm } from "./useClassificacaoForm";
+import { ModalAddQuestionToProva } from "./ModalAddQuestionToProva";
 
 /**
  * Tab de Classificação - Modo View e Edit
@@ -67,10 +68,14 @@ export function TabClassificacao({
     handleEdit,
     handleSave,
     handleCancel,
+    handleAddToProva,
+    handleRemoveFromProva,
+    handleSetProvaBase,
   } = useClassificacaoForm({ question, onSaveSuccess });
 
   // Estados para gerenciamento de status
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
   const [rejectionMessage, setRejectionMessage] = useState("");
   const [showRejectionInput, setShowRejectionInput] = useState(false);
 
@@ -348,10 +353,19 @@ export function TabClassificacao({
 
           {/* Botão Editar (aparece só no modo visualização) */}
           {!isEditing && canEdit && (
-            <Button size="sm" variant="outline" onClick={handleEdit}>
-              <Edit className="h-4 w-4 mr-2" />
-              Editar Classificação
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowAddModal(true)}
+              >
+                Adicionar em uma prova
+              </Button>
+              <Button size="sm" variant="outline" onClick={handleEdit}>
+                <Edit className="h-4 w-4 mr-2" />
+                Editar Classificação
+              </Button>
+            </div>
           )}
         </CardHeader>
 
@@ -845,6 +859,23 @@ export function TabClassificacao({
 
               <div className="flex gap-2">
                 <Button
+                  onClick={handleRemoveFromProva}
+                  disabled={isSaving}
+                  variant="outline"
+                  size="sm"
+                  className="text-red border-red"
+                >
+                  Remover da prova
+                </Button>
+                <Button
+                  onClick={handleSetProvaBase}
+                  disabled={isSaving || provaSel?.provaId === question.provaBase}
+                  variant="outline"
+                  size="sm"
+                >
+                  Transformar em provaBase
+                </Button>
+                <Button
                   onClick={handleCancel}
                   disabled={isSaving}
                   variant="outline"
@@ -876,6 +907,15 @@ export function TabClassificacao({
             </div>
           </CardContent>
         </Card>
+      )}
+
+      {showAddModal && (
+        <ModalAddQuestionToProva
+          provas={infos?.provas ?? []}
+          provaIdsJaVinculadas={provasContendo.map((p) => p.provaId)}
+          onConfirm={handleAddToProva}
+          onClose={() => setShowAddModal(false)}
+        />
       )}
     </div>
   );

--- a/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/useClassificacaoForm.ts
+++ b/src/pages/dashQuestionNew/modals/tabs/TabClassificacao/useClassificacaoForm.ts
@@ -1,5 +1,8 @@
 import { Question } from "@/dtos/question/questionDTO";
 import { useToastAsync } from "@/hooks/useToastAsync";
+import { addQuestionToProva } from "@/services/question/addQuestionToProva";
+import { removeQuestionFromProva } from "@/services/question/removeQuestionFromProva";
+import { setProvaBase as setProvaBaseService } from "@/services/question/setProvaBase";
 import { updateClassification } from "@/services/question/updateClassification";
 import { useAuthStore } from "@/store/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -128,6 +131,46 @@ export function useClassificacaoForm({
     setIsEditing(false);
   };
 
+  const handleAddToProva = async (provaId: string, numero: number) => {
+    await executeAsync({
+      action: () => addQuestionToProva(question._id, provaId, numero, token),
+      loadingMessage: "Adicionando à prova...",
+      successMessage: "✅ Questão adicionada à prova!",
+      errorMessage: "Erro ao adicionar à prova",
+      onSuccess: () => onSaveSuccess?.(),
+    });
+  };
+
+  const handleRemoveFromProva = async () => {
+    if (!provaSel?.provaId) return;
+    if (!confirm(`Remover a questão da prova "${provaSel.provaNome}"?`)) return;
+    await executeAsync({
+      action: () =>
+        removeQuestionFromProva(question._id, provaSel.provaId, token),
+      loadingMessage: "Removendo da prova...",
+      successMessage: "✅ Questão removida da prova!",
+      errorMessage: "Erro ao remover da prova",
+      onSuccess: () => {
+        setIsEditing(false);
+        onSaveSuccess?.();
+      },
+    });
+  };
+
+  const handleSetProvaBase = async () => {
+    if (!provaSel?.provaId) return;
+    await executeAsync({
+      action: () => setProvaBaseService(question._id, provaSel.provaId, token),
+      loadingMessage: "Definindo prova de origem...",
+      successMessage: "✅ Prova de origem atualizada!",
+      errorMessage: "Erro ao definir prova de origem",
+      onSuccess: () => {
+        setIsEditing(false);
+        onSaveSuccess?.();
+      },
+    });
+  };
+
   return {
     form,
     control: form.control,
@@ -143,5 +186,8 @@ export function useClassificacaoForm({
     handleEdit,
     handleSave,
     handleCancel,
+    handleAddToProva,
+    handleRemoveFromProva,
+    handleSetProvaBase,
   };
 }

--- a/src/services/question/addQuestionToProva.ts
+++ b/src/services/question/addQuestionToProva.ts
@@ -1,0 +1,27 @@
+import { StatusCodes } from "http-status-codes";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { questoes } from "../urls";
+
+export async function addQuestionToProva(
+  questaoId: string,
+  provaId: string,
+  numero: number,
+  token: string
+): Promise<void> {
+  const response = await fetchWrapper(`${questoes}/${questaoId}/provas`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ provaId, numero }),
+  });
+
+  if (
+    response.status !== StatusCodes.OK &&
+    response.status !== StatusCodes.CREATED
+  ) {
+    const res = await response.json().catch(() => ({}));
+    throw new Error(`Erro ao adicionar questão à prova - ${res.message ?? ""}`);
+  }
+}

--- a/src/services/question/removeQuestionFromProva.ts
+++ b/src/services/question/removeQuestionFromProva.ts
@@ -1,0 +1,25 @@
+import { StatusCodes } from "http-status-codes";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { questoes } from "../urls";
+
+export async function removeQuestionFromProva(
+  questaoId: string,
+  provaId: string,
+  token: string
+): Promise<void> {
+  const response = await fetchWrapper(
+    `${questoes}/${questaoId}/provas/${provaId}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  if (response.status !== StatusCodes.OK) {
+    const res = await response.json().catch(() => ({}));
+    throw new Error(`Erro ao remover questão da prova - ${res.message ?? ""}`);
+  }
+}

--- a/src/services/question/setProvaBase.ts
+++ b/src/services/question/setProvaBase.ts
@@ -1,0 +1,23 @@
+import { StatusCodes } from "http-status-codes";
+import fetchWrapper from "../../utils/fetchWrapper";
+import { questoes } from "../urls";
+
+export async function setProvaBase(
+  questaoId: string,
+  provaId: string,
+  token: string
+): Promise<void> {
+  const response = await fetchWrapper(`${questoes}/${questaoId}/prova-base`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ provaId }),
+  });
+
+  if (response.status !== StatusCodes.OK) {
+    const res = await response.json().catch(() => ({}));
+    throw new Error(`Erro ao definir prova de origem - ${res.message ?? ""}`);
+  }
+}


### PR DESCRIPTION
## Etapa 11 — parte client-vcnafacul

Gestão de vínculos questão↔prova a partir da aba **Classificação** do modal de detalhes da questão.

### UI
- **Modo visualização:** botão **"Adicionar em uma prova"** → modal secundário com **busca de prova por nome** (exclui provas já vinculadas) + select de número livre (`getMissingNumber`).
- **Modo edição:** **"Remover da prova"** (age no `provaSel`, com confirmação) e **"Transformar em provaBase"** (age no `provaSel`, desabilitado quando já é a base).
- Todas as ações disparam `refreshQuestion()` no sucesso.

### Camadas
- Serviços HTTP: `addQuestionToProva`, `removeQuestionFromProva`, `setProvaBase`.
- Handlers no hook `useClassificacaoForm`; componente `ModalAddQuestionToProva`.

Verificado com `tsc --noEmit` + `npm run build` (lint do repo está quebrado project-wide: ESLint v9 × `.eslintrc.cjs` — não relacionado a esta mudança).

### Deploy (lockstep) — **este PR é o 3º/último** (depois de ms #168 e api #510)

🤖 Generated with [Claude Code](https://claude.com/claude-code)