### PR TITLE
feat: UI do Cartão Resposta (OMR) — download e upload na dashProva (Etapa 12 C1–C2)

### DIFF
--- a/src/dtos/cartaoResposta/resultados.ts
+++ b/src/dtos/cartaoResposta/resultados.ts
@@ -1,0 +1,10 @@
+export interface EstudanteCartao {
+  userId: string;
+  nome: string;
+  matricula: string;
+}
+
+export interface ResultadosCartao {
+  estudante: EstudanteCartao;
+  historicos: Array<{ ano?: number; status?: string }>;
+}

--- a/src/pages/dashProvas/index.tsx
+++ b/src/pages/dashProvas/index.tsx
@@ -23,6 +23,7 @@ import { dashProva } from "./data";
 import NewProva from "./modals/newProva";
 import ShowProva from "./modals/showProva";
 import ManageCategorias from "./modals/manageCategorias";
+import UploadCartaoModal from "./modals/uploadCartaoModal";
 import { downloadSyncReportPdf } from "./utils/syncReportPdf";
 import { useModals } from "@/hooks/useModal";
 
@@ -50,6 +51,7 @@ function DashProva() {
     'modalNewProva',
     'modalShowProva',
     'modalManageCategorias',
+    'modalUploadCartao',
   ]);
 
   const {
@@ -311,6 +313,13 @@ function DashProva() {
       children: "Gerenciar Categorias",
     },
     {
+      disabled: !permissao[Roles.visualizarEstudantes],
+      onClick: () => modals.modalUploadCartao.open(),
+      typeStyle: "secondary",
+      size: "small",
+      children: "Enviar cartão",
+    },
+    {
       disabled: !hasActiveFilters,
       onClick: clearFilters,
       typeStyle: "refused",
@@ -351,6 +360,11 @@ function DashProva() {
       <ModalNewProva />
       <ModalShowProva />
       <ModalManageCategorias />
+      <UploadCartaoModal
+        isOpen={modals.modalUploadCartao.isOpen}
+        handleClose={modals.modalUploadCartao.close}
+        token={token}
+      />
     </DashCardContext.Provider>
   );
 }

--- a/src/pages/dashProvas/modals/simuladosView.tsx
+++ b/src/pages/dashProvas/modals/simuladosView.tsx
@@ -1,7 +1,13 @@
-import { ArrowLeftIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowLeftIcon,
+  ArrowDownTrayIcon,
+  PencilSquareIcon,
+} from "@heroicons/react/24/outline";
 import { Button } from "@mui/material";
 import { useState } from "react";
+import { toast } from "react-toastify";
 import { SimuladoResumo } from "../../../dtos/prova/prova";
+import { baixarCartao } from "../../../services/cartaoResposta/baixarCartao";
 import { formatDateTime } from "../../../utils/date";
 import { getStatus, isSemJanela } from "../../../utils/simuladoAvailability";
 import EditDisponibilidadeModal from "./editDisponibilidadeModal";
@@ -52,6 +58,36 @@ function SimuladosView({
   onSimuladoUpdated,
 }: SimuladosViewProps) {
   const [editing, setEditing] = useState<SimuladoResumo | null>(null);
+
+  const handleDownloadCartao = async (simulado: SimuladoResumo) => {
+    const id = toast.loading("Baixando cartão...");
+    try {
+      const blob = await baixarCartao(simulado._id, token);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `cartao_${simulado.nome}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      toast.update(id, {
+        render: "Cartão baixado com sucesso!",
+        type: "success",
+        isLoading: false,
+        autoClose: 3000,
+        closeOnClick: true,
+      });
+    } catch {
+      toast.update(id, {
+        render: "Erro ao baixar o cartão",
+        type: "error",
+        isLoading: false,
+        autoClose: 5000,
+        closeOnClick: true,
+      });
+    }
+  };
 
   return (
     <div>
@@ -125,13 +161,22 @@ function SimuladosView({
                   </td>
                   <td className="px-3 py-2">{renderStatus(simulado)}</td>
                   <td className="px-3 py-2">
-                    <button
-                      onClick={() => setEditing(simulado)}
-                      className="text-gray-400 hover:text-blue-600"
-                      aria-label="Editar janela"
-                    >
-                      <PencilSquareIcon className="h-4 w-4" />
-                    </button>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => handleDownloadCartao(simulado)}
+                        className="text-gray-400 hover:text-blue-600"
+                        aria-label="Baixar cartão de resposta"
+                      >
+                        <ArrowDownTrayIcon className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => setEditing(simulado)}
+                        className="text-gray-400 hover:text-blue-600"
+                        aria-label="Editar janela"
+                      >
+                        <PencilSquareIcon className="h-4 w-4" />
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/pages/dashProvas/modals/simuladosView.tsx
+++ b/src/pages/dashProvas/modals/simuladosView.tsx
@@ -164,7 +164,17 @@ function SimuladosView({
                     <div className="flex gap-2">
                       <button
                         onClick={() => handleDownloadCartao(simulado)}
-                        className="text-gray-400 hover:text-blue-600"
+                        disabled={simulado.bloqueado}
+                        title={
+                          simulado.bloqueado
+                            ? "Disponível só para simulados prontos"
+                            : "Baixar cartão de resposta"
+                        }
+                        className={
+                          simulado.bloqueado
+                            ? "text-gray-200 cursor-not-allowed"
+                            : "text-gray-400 hover:text-blue-600"
+                        }
                         aria-label="Baixar cartão de resposta"
                       >
                         <ArrowDownTrayIcon className="h-4 w-4" />

--- a/src/pages/dashProvas/modals/uploadCartaoModal.tsx
+++ b/src/pages/dashProvas/modals/uploadCartaoModal.tsx
@@ -131,7 +131,7 @@ export default function UploadCartaoModal({
             <button
               onClick={handleEnviar}
               disabled={!file || enviando}
-              className="w-full px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+              className="w-full px-4 py-2 bg-green2 text-white rounded disabled:opacity-50"
             >
               {enviando ? "Enviando..." : "Enviar cartão"}
             </button>

--- a/src/pages/dashProvas/modals/uploadCartaoModal.tsx
+++ b/src/pages/dashProvas/modals/uploadCartaoModal.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { toast } from "react-toastify";
+import ModalTemplate from "../../../components/templates/modalTemplate";
+import { ResultadosCartao } from "../../../dtos/cartaoResposta/resultados";
+import { buscarResultados } from "../../../services/cartaoResposta/buscarResultados";
+import { uploadCartao } from "../../../services/cartaoResposta/uploadCartao";
+
+interface UploadCartaoModalProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  token: string;
+}
+
+export default function UploadCartaoModal({
+  isOpen,
+  handleClose,
+  token,
+}: UploadCartaoModalProps) {
+  const [matricula, setMatricula] = useState("");
+  const [resultado, setResultado] = useState<ResultadosCartao | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [buscando, setBuscando] = useState(false);
+  const [enviando, setEnviando] = useState(false);
+
+  const reset = () => {
+    setMatricula("");
+    setResultado(null);
+    setFile(null);
+  };
+
+  const fechar = () => {
+    reset();
+    handleClose();
+  };
+
+  const handleBuscar = async () => {
+    if (!matricula.trim()) return;
+    setBuscando(true);
+    try {
+      setResultado(await buscarResultados(matricula.trim(), token));
+    } catch (err) {
+      setResultado(null);
+      toast.error((err as Error).message);
+    } finally {
+      setBuscando(false);
+    }
+  };
+
+  const handleEnviar = async () => {
+    if (!resultado || !file) return;
+    setEnviando(true);
+    const id = toast.loading("Enviando cartão...");
+    try {
+      await uploadCartao(file, resultado.estudante.userId, token);
+      toast.update(id, {
+        render: "Cartão enviado! Processando...",
+        type: "success",
+        isLoading: false,
+        autoClose: 3000,
+        closeOnClick: true,
+      });
+      fechar();
+    } catch (err) {
+      toast.update(id, {
+        render: (err as Error).message || "Erro ao enviar o cartão",
+        type: "error",
+        isLoading: false,
+        autoClose: 5000,
+        closeOnClick: true,
+      });
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <ModalTemplate
+      isOpen={isOpen}
+      handleClose={fechar}
+      className="w-full max-w-lg rounded-lg bg-white shadow-xl p-2"
+    >
+      <div className="p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Enviar cartão de resposta</h2>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={matricula}
+            onChange={(e) => setMatricula(e.target.value)}
+            placeholder="Matrícula do aluno"
+            className="flex-1 border rounded px-3 py-2"
+          />
+          <button
+            onClick={handleBuscar}
+            disabled={buscando}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            {buscando ? "Buscando..." : "Buscar"}
+          </button>
+        </div>
+
+        {resultado && (
+          <div className="space-y-3">
+            <div className="border rounded p-3">
+              <p className="font-medium">{resultado.estudante.nome}</p>
+              <p className="text-sm text-gray-500">
+                Matrícula: {resultado.estudante.matricula}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-sm text-gray-600 mb-1">
+                Últimos resultados: {resultado.historicos.length}
+              </p>
+              <ul className="text-sm max-h-32 overflow-auto divide-y">
+                {resultado.historicos.map((h, i) => (
+                  <li key={i} className="py-1 flex justify-between">
+                    <span>{h.ano ?? "—"}</span>
+                    <span className="text-gray-500">{h.status ?? ""}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+
+            <button
+              onClick={handleEnviar}
+              disabled={!file || enviando}
+              className="w-full px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+            >
+              {enviando ? "Enviando..." : "Enviar cartão"}
+            </button>
+          </div>
+        )}
+      </div>
+    </ModalTemplate>
+  );
+}

--- a/src/services/cartaoResposta/baixarCartao.ts
+++ b/src/services/cartaoResposta/baixarCartao.ts
@@ -1,0 +1,16 @@
+import { cartaoResposta } from "@/services/urls";
+
+export async function baixarCartao(
+  simuladoId: string,
+  token: string,
+): Promise<Blob> {
+  const response = await fetch(`${cartaoResposta}/${simuladoId}`, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error("Erro ao baixar o cartão");
+  }
+  return response.blob();
+}

--- a/src/services/cartaoResposta/buscarResultados.ts
+++ b/src/services/cartaoResposta/buscarResultados.ts
@@ -1,0 +1,23 @@
+import { ResultadosCartao } from "@/dtos/cartaoResposta/resultados";
+import { cartaoResposta } from "@/services/urls";
+import fetchWrapper from "@/utils/fetchWrapper";
+
+export async function buscarResultados(
+  matricula: string,
+  token: string,
+): Promise<ResultadosCartao> {
+  const response = await fetchWrapper(
+    `${cartaoResposta}/resultados?matricula=${encodeURIComponent(matricula)}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  if (response.status !== 200) {
+    throw new Error("Aluno não encontrado nesse cursinho");
+  }
+  return response.json();
+}

--- a/src/services/cartaoResposta/uploadCartao.ts
+++ b/src/services/cartaoResposta/uploadCartao.ts
@@ -1,0 +1,24 @@
+import { cartaoResposta } from "@/services/urls";
+import fetchWrapper from "@/utils/fetchWrapper";
+
+export async function uploadCartao(
+  file: File,
+  usuario: string,
+  token: string,
+): Promise<{ historicoId: string }> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("usuario", usuario);
+
+  const response = await fetchWrapper(`${cartaoResposta}/upload`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` }, // sem Content-Type → browser põe o multipart boundary
+    body: formData,
+  });
+
+  if (response.status === 400) throw new Error("QR do cartão ilegível");
+  if (response.status === 409) throw new Error("Cartão já enviado para este aluno");
+  if (response.status === 502) throw new Error("Serviço de leitura (OMR) indisponível");
+  if (response.status >= 400) throw new Error("Erro ao enviar o cartão");
+  return response.json();
+}

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -60,6 +60,7 @@ export const missing = `${prova}/missing`;
 export const cursinhoProva = `${mssimulado}/cursinho/prova`;
 export const questoes = `${mssimulado}/questoes`;
 export const historico = `${mssimulado}/historico`;
+export const cartaoResposta = `${mssimulado}/cartao-resposta`;
 export const auditLog = `${BASE_URL}/auditlog`;
 export const auditLogMs = `${BASE_URL}/auditlog/ms`;
 export const historyQuestion = `${mssimulado}/questoes/history`;


### PR DESCRIPTION
## Summary
UI do Cartão Resposta no client — Etapa 12 C1–C2:
- **C1**: botão "baixar cartão" na coluna de ações do `simuladosView` + serviço `baixarCartao`.
- **C2**: modal de upload (matrícula → B2 resultados → foto → B3 upload) + botão na dashProva.

Ajustes desta rodada:
- Botão de download **desabilitado quando o simulado não está pronto** (`bloqueado`), com tooltip.
- Cor do botão "Enviar cartão" — `bg-green-600` não existe na paleta custom (green é flat) → `bg-green2` (o botão estava invisível).

## Test Plan
- [x] `npx tsc --noEmit` limpo
- [x] Testado manualmente (download bloqueado vs pronto + fluxo de upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)